### PR TITLE
Chaos engineering: throttle type, config file, SDK helpers

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1025,6 +1025,20 @@ func main() {
 		}
 	}
 
+	// Load chaos rules from config file (these supplement any file-persisted rules).
+	for _, r := range cfg.Chaos.Rules {
+		chaosEngine.AddRule(gateway.ChaosRule{
+			Service:    r.Service,
+			Action:     r.Action,
+			Enabled:    true,
+			Type:       r.Type,
+			ErrorCode:  r.ErrorCode,
+			ErrorMsg:   r.ErrorMsg,
+			LatencyMs:  r.LatencyMs,
+			Percentage: r.Percentage,
+		})
+	}
+
 	// Admin API (with CORS for dashboard cross-origin access)
 	adminAPI := admin.NewWithDataPlane(cfg, registry, dp)
 	// Persistence for dashboards, saved views, and deploy events.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -199,6 +199,22 @@ func DefaultPricingConfig() PricingConfig {
 	}
 }
 
+// ChaosRule defines a fault injection rule loaded from the config file.
+type ChaosRule struct {
+	Service    string `yaml:"service"`
+	Action     string `yaml:"action"`
+	Type       string `yaml:"type"`
+	ErrorCode  int    `yaml:"error_code"`
+	ErrorMsg   string `yaml:"error_msg"`
+	LatencyMs  int    `yaml:"latency_ms"`
+	Percentage int    `yaml:"percentage"`
+}
+
+// ChaosConfig holds chaos/fault injection configuration.
+type ChaosConfig struct {
+	Rules []ChaosRule `yaml:"rules"`
+}
+
 // RateLimitConfig holds rate limiting configuration.
 type RateLimitConfig struct {
 	Enabled           bool    `yaml:"enabled" json:"enabled"`
@@ -286,6 +302,7 @@ type Config struct {
 	RateLimit   RateLimitConfig          `yaml:"rate_limit" json:"rate_limit"`
 	RUM         RUMConfig                `yaml:"rum" json:"rum"`
 	OTLP        OTLPConfig               `yaml:"otlp" json:"otlp"`
+	Chaos          ChaosConfig              `yaml:"chaos" json:"chaos"`
 	IaCDir         string                   `yaml:"iac_dir" json:"iac_dir"` // Path to Pulumi/Terraform project
 	IaCEnv         string                   `yaml:"iac_env" json:"iac_env"` // Environment name (dev/stage/prod)
 	SaaS           SaaSConfig               `yaml:"saas"`

--- a/pkg/gateway/chaos.go
+++ b/pkg/gateway/chaos.go
@@ -216,6 +216,17 @@ func ChaosMiddleware(next http.Handler, engine *ChaosEngine) http.Handler {
 				_, _ = w.Write([]byte(`{"__type":"ChaosTimeout","message":"Request timed out (chaos injection)"}`))
 				return
 
+			case "throttle":
+				w.Header().Set("X-Cloudmock-Chaos", rule.ID)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				msg := rule.ErrorMsg
+				if msg == "" {
+					msg = "Rate exceeded"
+				}
+				fmt.Fprintf(w, `{"__type":"ThrottlingException","Message":"%s"}`, msg)
+				return
+
 			case "blackhole":
 				// Hijack the connection and close it without sending a response.
 				hj, ok := w.(http.Hijacker)

--- a/pkg/gateway/logging.go
+++ b/pkg/gateway/logging.go
@@ -553,6 +553,10 @@ func LoggingMiddlewareWithOpts(next http.Handler, log *RequestLog, stats *Reques
 
 // detectServiceFromRequest extracts the service name without importing routing to avoid a cycle.
 func detectServiceFromRequest(r *http.Request) string {
+	// Fast path: in-process SDK sets this header during transport to avoid SigV4 parsing.
+	if svc := r.Header.Get("X-Cloudmock-Service"); svc != "" {
+		return svc
+	}
 	// Use the same logic as routing.DetectService but inline to avoid circular imports.
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		if svc := serviceFromAuth(auth); svc != "" {

--- a/sdk/chaos.go
+++ b/sdk/chaos.go
@@ -1,0 +1,51 @@
+package sdk
+
+import "github.com/neureaux/cloudmock/pkg/gateway"
+
+// ChaosOption configures a fault injection rule.
+type ChaosOption func(*chaosOpts)
+
+type chaosOpts struct {
+	statusCode int
+	message    string
+	latencyMs  int
+	percentage int
+}
+
+// WithStatusCode sets the HTTP status code returned for "error" faults.
+func WithStatusCode(code int) ChaosOption { return func(o *chaosOpts) { o.statusCode = code } }
+
+// WithMessage sets the error message returned with the fault.
+func WithMessage(msg string) ChaosOption { return func(o *chaosOpts) { o.message = msg } }
+
+// WithLatency sets the added latency in milliseconds for "latency" faults.
+func WithLatency(ms int) ChaosOption { return func(o *chaosOpts) { o.latencyMs = ms } }
+
+// WithPercentage sets the probability (0-100) that the fault fires on any given request.
+func WithPercentage(pct int) ChaosOption { return func(o *chaosOpts) { o.percentage = pct } }
+
+// InjectFault adds a fault injection rule to the in-process chaos engine.
+// faultType is one of "error", "latency", "timeout", "blackhole", or "throttle".
+func (cm *CloudMock) InjectFault(service, action, faultType string, opts ...ChaosOption) error {
+	o := &chaosOpts{statusCode: 500, percentage: 100}
+	for _, opt := range opts {
+		opt(o)
+	}
+	cm.chaosEngine.AddRule(gateway.ChaosRule{
+		Service:    service,
+		Action:     action,
+		Enabled:    true,
+		Type:       faultType,
+		ErrorCode:  o.statusCode,
+		ErrorMsg:   o.message,
+		LatencyMs:  o.latencyMs,
+		Percentage: o.percentage,
+	})
+	return nil
+}
+
+// ClearFaults disables all chaos rules on the in-process engine.
+func (cm *CloudMock) ClearFaults() error {
+	cm.chaosEngine.DisableAll()
+	return nil
+}

--- a/sdk/cloudmock.go
+++ b/sdk/cloudmock.go
@@ -52,9 +52,10 @@ func WithAccountID(id string) Option { return func(o *options) { o.accountID = i
 // CloudMock is an in-process AWS mock. All AWS SDK calls routed through its
 // Config() go directly to the gateway handler with zero network overhead.
 type CloudMock struct {
-	handler   http.Handler
-	transport *inProcessTransport
-	cfg       aws.Config
+	handler      http.Handler
+	transport    *inProcessTransport
+	cfg          aws.Config
+	chaosEngine  *gateway.ChaosEngine
 }
 
 // New creates a new in-process CloudMock instance. By default it uses a
@@ -103,7 +104,11 @@ func New(opts ...Option) *CloudMock {
 	}
 	gw.SetEventBus(bus)
 
-	transport := newInProcessTransport(gw)
+	// Create a chaos engine and wrap the gateway with chaos middleware.
+	chaosEngine := gateway.NewChaosEngine()
+	var handler http.Handler = gateway.ChaosMiddleware(gw, chaosEngine)
+
+	transport := newInProcessTransport(handler)
 
 	// Build the aws.Config that the caller will pass to SDK clients.
 	// Static credentials avoid per-call credential resolution and keep the
@@ -125,9 +130,10 @@ func New(opts ...Option) *CloudMock {
 	awsConfig.BaseEndpoint = aws.String("http://cloudmock.local")
 
 	return &CloudMock{
-		handler:   gw,
-		transport: transport,
-		cfg:       awsConfig,
+		handler:     handler,
+		transport:   transport,
+		cfg:         awsConfig,
+		chaosEngine: chaosEngine,
 	}
 }
 

--- a/sdk/cloudmock_test.go
+++ b/sdk/cloudmock_test.go
@@ -623,6 +623,65 @@ func TestInProcess_StateSnapshot(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Chaos injection tests
+// ---------------------------------------------------------------------------
+
+func TestChaos_InjectError(t *testing.T) {
+	cm := New()
+	defer cm.Close()
+
+	// Inject a 503 error on all S3 actions.
+	err := cm.InjectFault("s3", "*", "error", WithStatusCode(503), WithMessage("injected service unavailable"))
+	require.NoError(t, err)
+
+	client := newS3Client(cm)
+
+	// Create a bucket first (pre-fault for comparison).
+	// Now that the fault is active, any S3 call should return 503.
+	_, callErr := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	require.Error(t, callErr, "expected S3 call to fail with injected 503 fault")
+}
+
+func TestChaos_InjectThrottle(t *testing.T) {
+	cm := New()
+	defer cm.Close()
+
+	// Inject a throttle fault on DynamoDB.
+	err := cm.InjectFault("dynamodb", "*", "throttle", WithMessage("too many requests"))
+	require.NoError(t, err)
+
+	client := dynamodb.NewFromConfig(cm.Config())
+
+	// Any DynamoDB call should return 429 ThrottlingException.
+	_, callErr := client.ListTables(ctx, &dynamodb.ListTablesInput{})
+	require.Error(t, callErr, "expected DynamoDB call to fail with throttle fault")
+	assert.Contains(t, callErr.Error(), "429", "expected 429 status in error")
+}
+
+func TestChaos_ClearFaults(t *testing.T) {
+	cm := New()
+	defer cm.Close()
+
+	// Inject an S3 fault.
+	err := cm.InjectFault("s3", "*", "error", WithStatusCode(503))
+	require.NoError(t, err)
+
+	client := newS3Client(cm)
+
+	// Verify the fault is active.
+	_, callErr := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	require.Error(t, callErr, "fault should be active before clearing")
+
+	// Clear all faults.
+	err = cm.ClearFaults()
+	require.NoError(t, err)
+
+	// Now S3 calls should succeed.
+	_, callErr = client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	require.NoError(t, callErr, "S3 should work normally after clearing faults")
+}
+
+// ---------------------------------------------------------------------------
 // Benchmarks
 // ---------------------------------------------------------------------------
 

--- a/sdk/node/src/index.js
+++ b/sdk/node/src/index.js
@@ -126,6 +126,41 @@ class CloudMock {
   }
 
   /**
+   * Injects a fault rule into the running CloudMock instance.
+   *
+   * @param {string} service - AWS service name (e.g. "s3", "dynamodb", "*" for all).
+   * @param {string} action - API action (e.g. "GetObject") or "*" for all.
+   * @param {string} type - Fault type: "error", "latency", "timeout", "blackhole", or "throttle".
+   * @param {{ statusCode?: number, message?: string, latencyMs?: number, percentage?: number }} [opts]
+   * @returns {Promise<void>}
+   */
+  async injectFault(service, action, type, opts = {}) {
+    const body = JSON.stringify({
+      service,
+      action,
+      type,
+      enabled: true,
+      errorCode: opts.statusCode ?? 500,
+      errorMsg: opts.message ?? "",
+      latencyMs: opts.latencyMs ?? 0,
+      percentage: opts.percentage ?? 100,
+    });
+    await fetch(`${this.endpoint}/api/chaos`, {
+      method: "POST",
+      body,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  /**
+   * Disables all chaos rules on the running CloudMock instance.
+   * @returns {Promise<void>}
+   */
+  async clearFaults() {
+    await fetch(`${this.endpoint}/api/chaos`, { method: "DELETE" });
+  }
+
+  /**
    * Returns an AWS SDK v3 client configuration object.
    * Pass the return value directly to any client constructor:
    *

--- a/sdk/python/cloudmock/server.py
+++ b/sdk/python/cloudmock/server.py
@@ -151,6 +151,49 @@ class CloudMock:
             aws_secret_access_key="test",
         )
 
+    def inject_fault(self, service, action, fault_type, status_code=500, message="", latency_ms=0, percentage=100):
+        """Inject a fault rule into the running CloudMock instance.
+
+        Args:
+            service: AWS service name (e.g. "s3", "dynamodb", "*" for all).
+            action: API action name (e.g. "GetObject") or "*" for all.
+            fault_type: One of "error", "latency", "timeout", "blackhole", "throttle".
+            status_code: HTTP status code for "error" faults (default 500).
+            message: Error message body.
+            latency_ms: Milliseconds of added latency for "latency" faults.
+            percentage: Probability 0-100 that the fault fires (default 100).
+        """
+        import json
+        import urllib.request
+
+        rule = {
+            "service": service,
+            "action": action,
+            "type": fault_type,
+            "enabled": True,
+            "errorCode": status_code,
+            "errorMsg": message,
+            "latencyMs": latency_ms,
+            "percentage": percentage,
+        }
+        req = urllib.request.Request(
+            f"{self._endpoint.rstrip('/')}/api/chaos",
+            data=json.dumps(rule).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req)
+
+    def clear_faults(self):
+        """Disable all chaos rules on the running CloudMock instance."""
+        import urllib.request
+
+        req = urllib.request.Request(
+            f"{self._endpoint.rstrip('/')}/api/chaos",
+            method="DELETE",
+        )
+        urllib.request.urlopen(req)
+
     def __enter__(self):
         self.start()
         return self

--- a/website/src/content/docs/docs/devtools/chaos.md
+++ b/website/src/content/docs/docs/devtools/chaos.md
@@ -7,13 +7,15 @@ The Chaos view lets you inject faults into any AWS service emulated by CloudMock
 
 ## Fault types
 
-CloudMock supports three types of fault injection:
+CloudMock supports five types of fault injection:
 
 | Type | Effect | Value |
 |------|--------|-------|
 | **Latency** | Adds artificial delay before responding | Milliseconds to add (e.g., 2000 for 2 seconds) |
 | **Error** | Returns an HTTP error status code instead of the real response | HTTP status code (e.g., 503 for Service Unavailable) |
-| **Throttle** | Randomly fails a percentage of requests with a throttling error | Percentage of requests to fail (e.g., 50 for 50%) |
+| **Throttle** | Returns HTTP 429 with a `ThrottlingException` body | Percentage of requests to throttle (e.g., 50 for 50%) |
+| **Timeout** | Holds the connection for 30 seconds then returns 504 | — |
+| **Blackhole** | Closes the connection without sending any response | — |
 
 ## Creating rules
 
@@ -109,6 +111,81 @@ curl -X PUT http://localhost:4599/api/chaos/RULE_ID \
 
 ```bash
 curl -X DELETE http://localhost:4599/api/chaos/RULE_ID
+```
+
+## Config file support
+
+You can define chaos rules in `cloudmock.yaml` so they are active at startup. Config-file rules are always enabled and supplement rules managed through the UI or API.
+
+```yaml
+chaos:
+  rules:
+    - service: dynamodb
+      action: "*"
+      type: latency
+      latency_ms: 200
+      percentage: 100
+
+    - service: s3
+      action: GetObject
+      type: error
+      error_code: 503
+      error_msg: "Injected read failure"
+      percentage: 25
+
+    - service: sqs
+      action: "*"
+      type: throttle
+      percentage: 10
+```
+
+| Field | Description |
+|-------|-------------|
+| `service` | Target service (`"s3"`, `"dynamodb"`, `"*"` for all) |
+| `action` | Target API action or `"*"` for all |
+| `type` | `error`, `latency`, `timeout`, `blackhole`, or `throttle` |
+| `error_code` | HTTP status code for `error` faults |
+| `error_msg` | Error message body |
+| `latency_ms` | Milliseconds of added latency |
+| `percentage` | 0–100 probability the fault fires per request |
+
+## SDK helpers
+
+### Go (in-process)
+
+```go
+cm := sdk.New()
+defer cm.Close()
+
+// Inject a throttle on DynamoDB.
+cm.InjectFault("dynamodb", "*", "throttle")
+
+// Inject a 503 on 50% of S3 GetObject calls.
+cm.InjectFault("s3", "GetObject", "error",
+    sdk.WithStatusCode(503),
+    sdk.WithPercentage(50),
+)
+
+// Remove all active faults.
+cm.ClearFaults()
+```
+
+See the [Chaos Testing guide](/docs/guides/chaos-testing) for full examples covering retries, circuit breakers, and timeout handling.
+
+### Python
+
+```python
+with CloudMock() as cm:
+    cm.inject_fault("dynamodb", "*", "throttle", percentage=100)
+    cm.clear_faults()
+```
+
+### Node.js
+
+```javascript
+const cm = await mockAWS();
+await cm.injectFault("s3", "*", "error", { statusCode: 503 });
+await cm.clearFaults();
 ```
 
 ## Admin API endpoints

--- a/website/src/content/docs/docs/guides/chaos-testing.md
+++ b/website/src/content/docs/docs/guides/chaos-testing.md
@@ -1,0 +1,311 @@
+---
+title: Chaos Testing
+description: Inject faults into CloudMock services to test retries, circuit breakers, and timeout handling
+---
+
+Chaos testing verifies that your application handles AWS failures gracefully — throttling, transient errors, network partitions, and latency spikes. CloudMock lets you inject these faults deterministically in unit and integration tests, without flaky real-AWS behavior.
+
+## Fault types
+
+| Type | Effect |
+|------|--------|
+| `error` | Returns a configurable HTTP error status code |
+| `latency` | Adds artificial delay before responding |
+| `timeout` | Holds the connection for 30 seconds then returns 504 |
+| `blackhole` | Closes the connection without sending any response |
+| `throttle` | Returns HTTP 429 with a `ThrottlingException` body |
+
+---
+
+## Go: in-process SDK
+
+The Go SDK injects faults directly into the embedded gateway engine — no HTTP round-trips needed.
+
+### Basic usage
+
+```go
+import "github.com/neureaux/cloudmock/sdk"
+
+func TestRetryOnThrottle(t *testing.T) {
+    cm := sdk.New()
+    defer cm.Close()
+
+    // Inject a DynamoDB throttle on all actions.
+    cm.InjectFault("dynamodb", "*", "throttle")
+
+    client := dynamodb.NewFromConfig(cm.Config())
+    _, err := client.GetItem(ctx, &dynamodb.GetItemInput{...})
+    // err will be a ThrottlingException (HTTP 429)
+}
+```
+
+### Available options
+
+```go
+cm.InjectFault("s3", "GetObject", "error",
+    sdk.WithStatusCode(503),           // HTTP status code (default: 500)
+    sdk.WithMessage("Service Unavailable"),
+    sdk.WithPercentage(50),            // Fire on 50% of matching requests
+)
+
+cm.InjectFault("dynamodb", "*", "latency",
+    sdk.WithLatency(2000),             // Add 2 seconds of latency
+)
+```
+
+### Testing retry logic
+
+```go
+func TestRetryExhaustion(t *testing.T) {
+    cm := sdk.New()
+    defer cm.Close()
+
+    // Fail all S3 calls with 503 Service Unavailable.
+    cm.InjectFault("s3", "*", "error",
+        sdk.WithStatusCode(503),
+        sdk.WithMessage("Service Unavailable"),
+    )
+
+    client := s3.NewFromConfig(cm.Config(), func(o *s3.Options) {
+        o.UsePathStyle = true
+    })
+
+    _, err := client.GetObject(ctx, &s3.GetObjectInput{
+        Bucket: aws.String("my-bucket"),
+        Key:    aws.String("my-key"),
+    })
+    require.Error(t, err)
+    // Verify your retry logic exhausted the configured max attempts.
+}
+```
+
+### Testing circuit breaker behavior
+
+```go
+func TestCircuitBreaker(t *testing.T) {
+    cm := sdk.New()
+    defer cm.Close()
+
+    // Inject errors on 80% of DynamoDB calls to simulate degraded service.
+    cm.InjectFault("dynamodb", "*", "error",
+        sdk.WithStatusCode(500),
+        sdk.WithPercentage(80),
+    )
+
+    // Run your service logic — circuit breaker should open after enough failures.
+    err := yourService.DoSomething(ctx, cm.Config())
+    assert.True(t, yourService.CircuitIsOpen())
+
+    // Clear faults — circuit breaker should close after recovery.
+    cm.ClearFaults()
+    err = yourService.DoSomething(ctx, cm.Config())
+    assert.NoError(t, err)
+    assert.False(t, yourService.CircuitIsOpen())
+}
+```
+
+### Testing timeout handling
+
+```go
+func TestTimeoutHandling(t *testing.T) {
+    cm := sdk.New()
+    defer cm.Close()
+
+    // Simulate a hung Lambda service.
+    cm.InjectFault("lambda", "*", "timeout")
+
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+
+    client := lambda.NewFromConfig(cm.Config())
+    _, err := client.Invoke(ctx, &lambda.InvokeInput{
+        FunctionName: aws.String("my-function"),
+    })
+
+    // The context deadline should fire before the 30-second chaos timeout.
+    require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+```
+
+---
+
+## Python: pytest
+
+Install the Python SDK:
+
+```bash
+pip install cloudmock
+```
+
+Use `inject_fault()` and `clear_faults()` on a running instance:
+
+```python
+import pytest
+from cloudmock import CloudMock
+
+@pytest.fixture(scope="module")
+def cm():
+    with CloudMock() as instance:
+        yield instance
+
+def test_retry_on_throttle(cm):
+    cm.inject_fault("dynamodb", "*", "throttle",
+        message="Rate exceeded", percentage=100)
+
+    ddb = cm.boto3_client("dynamodb")
+    with pytest.raises(Exception) as exc_info:
+        ddb.list_tables()
+    assert "ThrottlingException" in str(exc_info.value)
+
+def test_recovery_after_clear(cm):
+    cm.inject_fault("s3", "*", "error", status_code=503)
+
+    s3 = cm.boto3_client("s3")
+    with pytest.raises(Exception):
+        s3.list_buckets()
+
+    cm.clear_faults()
+    # Now requests should succeed.
+    response = s3.list_buckets()
+    assert "Buckets" in response
+```
+
+### pytest fixture with automatic cleanup
+
+```python
+@pytest.fixture
+def chaos_cm(cm):
+    """Yields the CloudMock instance and automatically clears faults after each test."""
+    yield cm
+    cm.clear_faults()
+
+def test_s3_503(chaos_cm):
+    chaos_cm.inject_fault("s3", "*", "error", status_code=503)
+    s3 = chaos_cm.boto3_client("s3")
+    with pytest.raises(Exception):
+        s3.list_buckets()
+    # clear_faults() called automatically by fixture teardown
+```
+
+---
+
+## Node.js: Jest
+
+Install the Node SDK:
+
+```bash
+npm install @cloudmock/sdk
+```
+
+```javascript
+const { mockAWS } = require("@cloudmock/sdk");
+const { S3Client, ListBucketsCommand } = require("@aws-sdk/client-s3");
+const { DynamoDBClient, ListTablesCommand } = require("@aws-sdk/client-dynamodb");
+
+let cm;
+
+beforeAll(async () => {
+    cm = await mockAWS();
+});
+
+afterAll(async () => {
+    await cm.stop();
+});
+
+afterEach(async () => {
+    await cm.clearFaults();
+});
+
+test("S3 returns 503 when error fault is active", async () => {
+    await cm.injectFault("s3", "*", "error", { statusCode: 503 });
+    const s3 = new S3Client(cm.clientConfig());
+    await expect(s3.send(new ListBucketsCommand({}))).rejects.toThrow();
+});
+
+test("DynamoDB returns 429 when throttle fault is active", async () => {
+    await cm.injectFault("dynamodb", "*", "throttle", {
+        message: "Rate exceeded",
+    });
+    const ddb = new DynamoDBClient(cm.clientConfig());
+    await expect(ddb.send(new ListTablesCommand({}))).rejects.toThrow(/429/);
+});
+
+test("normal operation resumes after clearing faults", async () => {
+    await cm.injectFault("s3", "*", "error", { statusCode: 500 });
+    await cm.clearFaults();
+    const s3 = new S3Client(cm.clientConfig());
+    // Should not throw.
+    const response = await s3.send(new ListBucketsCommand({}));
+    expect(response.Buckets).toBeDefined();
+});
+```
+
+---
+
+## Config file: static fault injection
+
+You can define chaos rules in your `cloudmock.yaml` so they are active at startup. This is useful for integration test environments where you always want certain fault conditions present.
+
+```yaml
+# cloudmock.yaml
+chaos:
+  rules:
+    - service: dynamodb
+      action: "*"
+      type: latency
+      latency_ms: 100
+      percentage: 100
+
+    - service: s3
+      action: GetObject
+      type: error
+      error_code: 503
+      error_msg: "Injected S3 read failure"
+      percentage: 25
+```
+
+Config-file rules are loaded once at startup and immediately active. They supplement any rules managed through the admin API or devtools UI.
+
+### Config rule fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `service` | string | Target service (`"s3"`, `"dynamodb"`, `"*"` for all) |
+| `action` | string | Target API action or `"*"` for all |
+| `type` | string | `error`, `latency`, `timeout`, `blackhole`, or `throttle` |
+| `error_code` | int | HTTP status code for `error` faults |
+| `error_msg` | string | Error message returned with the fault |
+| `latency_ms` | int | Milliseconds of added latency for `latency` faults |
+| `percentage` | int | 0–100 probability the fault fires per request |
+
+---
+
+## Common patterns
+
+### Retry testing
+
+Verify that your retry configuration actually retries on transient errors:
+
+```go
+// Use 50% failure rate to test that retries succeed when the service recovers.
+cm.InjectFault("s3", "*", "error",
+    sdk.WithStatusCode(503),
+    sdk.WithPercentage(50),
+)
+```
+
+### Circuit breaker testing
+
+Inject 100% failures to trigger circuit opening, then `ClearFaults()` to simulate recovery.
+
+### Timeout handling
+
+Use `"timeout"` fault type to simulate hung connections. Pair with a short `context.WithTimeout` to verify your application's timeout handling fires before the chaos timeout.
+
+### Partial degradation
+
+Use `WithPercentage` to simulate a partially degraded service. For example, 10% error rate to test that your application handles occasional failures without completely failing.
+
+### Throttle handling
+
+Use `"throttle"` to verify that your application respects AWS rate limits and implements exponential backoff correctly.


### PR DESCRIPTION
## Summary

- Added `throttle` fault type (429 ThrottlingException)
- Config file support for chaos rules in cloudmock.yml
- Go SDK: `InjectFault()` / `ClearFaults()` (in-process, zero HTTP)
- Python SDK: `inject_fault()` / `clear_faults()`
- Node SDK: `injectFault()` / `clearFaults()`
- Fixed service detection for in-process chaos (X-Cloudmock-Service header)
- Testing guide + updated devtools docs

## Test plan

- [x] TestChaos_InjectError — S3 503 fault injection
- [x] TestChaos_InjectThrottle — DynamoDB throttle (429)
- [x] TestChaos_ClearFaults — inject then clear, normal behavior resumes
- [x] All gateway tests pass
- [x] All SDK tests pass