### PR TITLE
Contract testing: dual-mode proxy validates CloudMock against real AWS

### DIFF
--- a/cmd/cloudmock/main.go
+++ b/cmd/cloudmock/main.go
@@ -52,6 +52,8 @@ func main() {
 		cmdReplay(adminAddr, os.Args[2:])
 	case "validate":
 		cmdValidate(adminAddr, os.Args[2:])
+	case "contract":
+		cmdContract(os.Args[2:])
 	case "version":
 		cmdVersion()
 	case "config":
@@ -77,6 +79,7 @@ Commands:
   record     Record real AWS traffic via proxy
   replay     Replay a recording against CloudMock
   validate   Replay + compare + exit code (CI mode)
+  contract   Dual-mode proxy: compare real AWS vs CloudMock live
   config     Show current configuration
   version    Print version information
   help       Show this help message
@@ -481,4 +484,124 @@ func cmdConfig(adminAddr string) {
 
 	data, _ := json.MarshalIndent(cfg, "", "  ")
 	fmt.Println(string(data))
+}
+
+func cmdContract(args []string) {
+	fs := flag.NewFlagSet("contract", flag.ExitOnError)
+	cloudmockURL := fs.String("cloudmock", "http://localhost:4566", "CloudMock endpoint URL")
+	region := fs.String("region", "us-east-1", "AWS region for forwarding requests")
+	port := fs.String("port", "4577", "local port for the contract proxy")
+	output := fs.String("output", "contract-report.json", "path to write the JSON report")
+	ignorePaths := fs.String("ignore-paths", "RequestId,ResponseMetadata", "comma-separated JSON paths to ignore in comparison")
+	runCmd := fs.String("run", "", "command to execute (proxy starts, runs command, generates report)")
+	fs.Parse(args)
+
+	var ignore []string
+	if *ignorePaths != "" {
+		for _, p := range strings.Split(*ignorePaths, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				ignore = append(ignore, p)
+			}
+		}
+	}
+
+	cp := proxy.NewContractProxy(*region, *cloudmockURL, ignore)
+
+	listener, err := net.Listen("tcp", ":"+*port)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: cannot listen on port %s: %v\n", *port, err)
+		os.Exit(1)
+	}
+
+	srv := &http.Server{Handler: cp}
+
+	if *runCmd != "" {
+		// Run mode: start proxy, execute command, generate report, exit.
+		go func() {
+			if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
+		}()
+
+		proxyAddr := fmt.Sprintf("http://localhost:%s", *port)
+		fmt.Printf("Contract proxy running on %s\n", proxyAddr)
+		fmt.Printf("Executing: %s\n", *runCmd)
+
+		cmd := exec.Command("sh", "-c", *runCmd)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Env = append(os.Environ(), "AWS_ENDPOINT_URL="+proxyAddr)
+		cmdErr := cmd.Run()
+
+		srv.Shutdown(context.Background())
+
+		if err := cp.SaveReport(*output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving report: %v\n", err)
+			os.Exit(1)
+		}
+
+		report := cp.Report()
+		printContractSummary(report, *output)
+
+		if cmdErr != nil {
+			fmt.Fprintf(os.Stderr, "\nCommand failed: %v\n", cmdErr)
+			os.Exit(1)
+		}
+		if report.Mismatched > 0 {
+			os.Exit(1)
+		}
+	} else {
+		// Interactive mode: start proxy, wait for signal, generate report.
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+		defer stop()
+
+		go func() {
+			proxyAddr := fmt.Sprintf("http://localhost:%s", *port)
+			fmt.Printf("Contract proxy running on %s\n", proxyAddr)
+			fmt.Printf("CloudMock endpoint: %s\n", *cloudmockURL)
+			fmt.Printf("AWS region: %s\n", *region)
+			fmt.Println("Press Ctrl+C to stop and generate the report.")
+			if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
+		}()
+
+		<-ctx.Done()
+		fmt.Println("\nStopping contract proxy...")
+		srv.Shutdown(context.Background())
+
+		if err := cp.SaveReport(*output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving report: %v\n", err)
+			os.Exit(1)
+		}
+
+		report := cp.Report()
+		printContractSummary(report, *output)
+
+		if report.Mismatched > 0 {
+			os.Exit(1)
+		}
+	}
+}
+
+func printContractSummary(report *proxy.ContractReport, outputPath string) {
+	fmt.Printf("\nContract Test Report\n")
+	fmt.Printf("  Total requests:  %d\n", report.TotalRequests)
+	fmt.Printf("  Matched:         %d\n", report.Matched)
+	fmt.Printf("  Mismatched:      %d\n", report.Mismatched)
+	fmt.Printf("  Compatibility:   %.1f%%\n", report.CompatibilityPct)
+
+	for svc, sr := range report.ByService {
+		fmt.Printf("  %s: %d/%d (%.1f%%)\n", svc, sr.Matched, sr.Total, sr.Pct)
+	}
+
+	for _, m := range report.Mismatches {
+		fmt.Printf("\n  [%s] %s.%s: AWS %d vs CloudMock %d (%s)\n", m.Severity, m.Service, m.Action, m.AWSStatus, m.CloudMockStatus, m.Severity)
+		for _, d := range m.Diffs {
+			fmt.Printf("    - %s\n", d)
+		}
+	}
+
+	fmt.Printf("\nReport written to %s\n", outputPath)
 }

--- a/npm/cloudmock/README.md
+++ b/npm/cloudmock/README.md
@@ -107,6 +107,22 @@ cfg.HTTPClient = &http.Client{Transport: recorder.Wrap(http.DefaultTransport)}
 recorder.SaveToFile("recording.json")
 ```
 
+## Contract Testing
+
+Verify CloudMock fidelity against real AWS in real time. The dual-mode proxy sends every request to both endpoints, diffs the responses, and produces a compatibility report.
+
+```bash
+# Run your test suite through the contract proxy
+cloudmock contract \
+  --cloudmock http://localhost:4566 \
+  --port 4577 \
+  --ignore-paths RequestId,ResponseMetadata \
+  --run "npm test"
+
+# Outputs contract-report.json with per-service compatibility %
+# Exit code 0 = 100% match, 1 = mismatches found
+```
+
 ## Links
 
 - [Documentation](https://cloudmock.io/docs)

--- a/pkg/proxy/contract.go
+++ b/pkg/proxy/contract.go
@@ -1,0 +1,338 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/neureaux/cloudmock/pkg/traffic"
+)
+
+// ContractProxy is a dual-mode proxy that sends each incoming request to both
+// real AWS and a local CloudMock instance, compares the responses, and returns
+// the real AWS response to the caller. The comparison results are stored for
+// later report generation.
+type ContractProxy struct {
+	awsProxy          *AWSProxy
+	cloudmockEndpoint string
+	results           []*ContractResult
+	mu                sync.Mutex
+	ignorePaths       []string
+	httpClient        *http.Client
+}
+
+// ContractResult holds the comparison outcome for a single request pair.
+type ContractResult struct {
+	Timestamp       time.Time
+	Service         string
+	Action          string
+	Method          string
+	Path            string
+	AWSStatus       int
+	AWSBody         []byte
+	CloudMockStatus int
+	CloudMockBody   []byte
+	Match           bool
+	Diffs           []string
+	Severity        string
+	LatencyAWS      time.Duration
+	LatencyCM       time.Duration
+}
+
+// ContractReport is the JSON-serialisable summary of a contract test run.
+type ContractReport struct {
+	StartedAt        string                    `json:"started_at"`
+	DurationSec      float64                   `json:"duration_sec"`
+	TotalRequests    int                       `json:"total_requests"`
+	Matched          int                       `json:"matched"`
+	Mismatched       int                       `json:"mismatched"`
+	CompatibilityPct float64                   `json:"compatibility_pct"`
+	ByService        map[string]*ServiceReport `json:"by_service"`
+	Mismatches       []MismatchEntry           `json:"mismatches"`
+}
+
+// ServiceReport provides per-service match statistics.
+type ServiceReport struct {
+	Total   int     `json:"total"`
+	Matched int     `json:"matched"`
+	Pct     float64 `json:"pct"`
+}
+
+// MismatchEntry is a single mismatched request in the report.
+type MismatchEntry struct {
+	Service         string   `json:"service"`
+	Action          string   `json:"action"`
+	AWSStatus       int      `json:"aws_status"`
+	CloudMockStatus int      `json:"cloudmock_status"`
+	Diffs           []string `json:"diffs"`
+	Severity        string   `json:"severity"`
+}
+
+// NewContractProxy creates a ContractProxy that forwards to real AWS via
+// AWSProxy and simultaneously to the given CloudMock endpoint.
+func NewContractProxy(region string, cloudmockEndpoint string, ignorePaths []string) *ContractProxy {
+	return &ContractProxy{
+		awsProxy:          New(region),
+		cloudmockEndpoint: strings.TrimRight(cloudmockEndpoint, "/"),
+		ignorePaths:       ignorePaths,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// ServeHTTP handles an incoming request by sending it to both real AWS and
+// CloudMock concurrently, comparing the responses, and returning the real
+// AWS response to the caller.
+func (cp *ContractProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Buffer the request body so we can send it to both endpoints.
+	var reqBody []byte
+	if r.Body != nil {
+		reqBody, _ = io.ReadAll(r.Body)
+		r.Body.Close()
+	}
+
+	svc := detectServiceFromAuth(r)
+	action := detectAction(r)
+
+	type proxyResult struct {
+		statusCode int
+		headers    http.Header
+		body       []byte
+		err        error
+		latency    time.Duration
+	}
+
+	var awsRes, cmRes proxyResult
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Forward to real AWS.
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+
+		// Build a new request with the buffered body for the AWSProxy.
+		awsReq, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.RequestURI(), bytes.NewReader(reqBody))
+		if err != nil {
+			awsRes.err = err
+			return
+		}
+		for k, vals := range r.Header {
+			for _, v := range vals {
+				awsReq.Header.Add(k, v)
+			}
+		}
+		awsReq.Host = r.Host
+
+		rec := &responseRecorder{headers: make(http.Header)}
+		cp.awsProxy.ServeHTTP(rec, awsReq)
+
+		awsRes.statusCode = rec.statusCode
+		awsRes.headers = rec.headers
+		awsRes.body = rec.body.Bytes()
+		awsRes.latency = time.Since(start)
+	}()
+
+	// Forward to CloudMock.
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+
+		targetURL := cp.cloudmockEndpoint + r.URL.RequestURI()
+		cmReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, bytes.NewReader(reqBody))
+		if err != nil {
+			cmRes.err = err
+			return
+		}
+		for k, vals := range r.Header {
+			for _, v := range vals {
+				cmReq.Header.Add(k, v)
+			}
+		}
+
+		resp, err := cp.httpClient.Do(cmReq)
+		if err != nil {
+			cmRes.err = err
+			cmRes.latency = time.Since(start)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		cmRes.statusCode = resp.StatusCode
+		cmRes.headers = resp.Header
+		cmRes.body = body
+		cmRes.latency = time.Since(start)
+	}()
+
+	wg.Wait()
+
+	// Compare responses.
+	result := &ContractResult{
+		Timestamp:       time.Now(),
+		Service:         svc,
+		Action:          action,
+		Method:          r.Method,
+		Path:            r.URL.Path,
+		AWSStatus:       awsRes.statusCode,
+		AWSBody:         awsRes.body,
+		CloudMockStatus: cmRes.statusCode,
+		CloudMockBody:   cmRes.body,
+		LatencyAWS:      awsRes.latency,
+		LatencyCM:       cmRes.latency,
+	}
+
+	if awsRes.err != nil || cmRes.err != nil {
+		result.Match = false
+		if awsRes.err != nil {
+			result.Diffs = append(result.Diffs, "AWS error: "+awsRes.err.Error())
+		}
+		if cmRes.err != nil {
+			result.Diffs = append(result.Diffs, "CloudMock error: "+cmRes.err.Error())
+		}
+		result.Severity = "error"
+	} else {
+		result.Match = true
+
+		// Compare status codes.
+		if awsRes.statusCode != cmRes.statusCode {
+			result.Match = false
+			result.Diffs = append(result.Diffs, fmt.Sprintf("status: %d -> %d", awsRes.statusCode, cmRes.statusCode))
+			result.Severity = "status"
+		}
+
+		// Compare response bodies.
+		bodyDiffs := traffic.CompareJSON(awsRes.body, cmRes.body, cp.ignorePaths)
+		if len(bodyDiffs) > 0 {
+			result.Match = false
+			result.Diffs = append(result.Diffs, bodyDiffs...)
+			if result.Severity == "" {
+				for _, d := range bodyDiffs {
+					if strings.Contains(d, "missing key") || strings.Contains(d, "extra key") {
+						result.Severity = "schema"
+						break
+					}
+				}
+				if result.Severity == "" {
+					result.Severity = "data"
+				}
+			}
+		}
+	}
+
+	cp.mu.Lock()
+	cp.results = append(cp.results, result)
+	cp.mu.Unlock()
+
+	// Return the real AWS response to the caller.
+	if awsRes.err != nil {
+		http.Error(w, "upstream AWS request failed: "+awsRes.err.Error(), http.StatusBadGateway)
+		return
+	}
+	for k, vals := range awsRes.headers {
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(awsRes.statusCode)
+	w.Write(awsRes.body)
+}
+
+// Results returns a copy of all contract comparison results.
+func (cp *ContractProxy) Results() []*ContractResult {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	out := make([]*ContractResult, len(cp.results))
+	copy(out, cp.results)
+	return out
+}
+
+// Report generates a ContractReport summarising the contract test run.
+func (cp *ContractProxy) Report() *ContractReport {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	report := &ContractReport{
+		StartedAt:     cp.awsProxy.startTime.Format(time.RFC3339),
+		DurationSec:   time.Since(cp.awsProxy.startTime).Seconds(),
+		TotalRequests: len(cp.results),
+		ByService:     make(map[string]*ServiceReport),
+	}
+
+	for _, r := range cp.results {
+		svc := r.Service
+		if svc == "" {
+			svc = "unknown"
+		}
+
+		sr, ok := report.ByService[svc]
+		if !ok {
+			sr = &ServiceReport{}
+			report.ByService[svc] = sr
+		}
+		sr.Total++
+
+		if r.Match {
+			report.Matched++
+			sr.Matched++
+		} else {
+			report.Mismatched++
+			report.Mismatches = append(report.Mismatches, MismatchEntry{
+				Service:         r.Service,
+				Action:          r.Action,
+				AWSStatus:       r.AWSStatus,
+				CloudMockStatus: r.CloudMockStatus,
+				Diffs:           r.Diffs,
+				Severity:        r.Severity,
+			})
+		}
+	}
+
+	if report.TotalRequests > 0 {
+		report.CompatibilityPct = float64(report.Matched) / float64(report.TotalRequests) * 100
+	}
+	for _, sr := range report.ByService {
+		if sr.Total > 0 {
+			sr.Pct = float64(sr.Matched) / float64(sr.Total) * 100
+		}
+	}
+
+	return report
+}
+
+// SaveReport writes the contract report as JSON to the given file path.
+func (cp *ContractProxy) SaveReport(path string) error {
+	report := cp.Report()
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// responseRecorder captures an http.Handler's response without writing to a
+// real http.ResponseWriter. Used to intercept the AWSProxy response.
+type responseRecorder struct {
+	statusCode int
+	headers    http.Header
+	body       bytes.Buffer
+}
+
+func (rr *responseRecorder) Header() http.Header {
+	return rr.headers
+}
+
+func (rr *responseRecorder) Write(b []byte) (int, error) {
+	return rr.body.Write(b)
+}
+
+func (rr *responseRecorder) WriteHeader(code int) {
+	rr.statusCode = code
+}

--- a/pkg/proxy/contract_test.go
+++ b/pkg/proxy/contract_test.go
@@ -1,0 +1,272 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContract_BothEndpointsHit(t *testing.T) {
+	var awsHits, cmHits int32
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&awsHits, 1)
+		w.WriteHeader(200)
+		w.Write([]byte(`{"Items":[],"Count":0}`))
+	}))
+	defer awsServer.Close()
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&cmHits, 1)
+		w.WriteHeader(200)
+		w.Write([]byte(`{"Items":[],"Count":0}`))
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, nil)
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+	w := httptest.NewRecorder()
+	cp.ServeHTTP(w, req)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&awsHits), "AWS endpoint should be hit once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&cmHits), "CloudMock endpoint should be hit once")
+	assert.Equal(t, 200, w.Code, "should return AWS response status")
+}
+
+func TestContract_AWSResponseReturned(t *testing.T) {
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"source":"aws"}`))
+	}))
+	defer awsServer.Close()
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"source":"cloudmock"}`))
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, nil)
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+	w := httptest.NewRecorder()
+	cp.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), `"source":"aws"`, "caller should receive the AWS response")
+}
+
+func TestContract_MatchRecorded(t *testing.T) {
+	body := `{"Items":[],"Count":0}`
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(body))
+	}))
+	defer awsServer.Close()
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(body))
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, nil)
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+	w := httptest.NewRecorder()
+	cp.ServeHTTP(w, req)
+
+	results := cp.Results()
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Match, "identical responses should match")
+	assert.Empty(t, results[0].Diffs)
+}
+
+func TestContract_MismatchDetected(t *testing.T) {
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer awsServer.Close()
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`{"ok":false}`))
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, nil)
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+	w := httptest.NewRecorder()
+	cp.ServeHTTP(w, req)
+
+	results := cp.Results()
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Match)
+	assert.Equal(t, "status", results[0].Severity)
+	assert.Equal(t, 200, results[0].AWSStatus)
+	assert.Equal(t, 500, results[0].CloudMockStatus)
+}
+
+func TestContract_BodyDiffCaptured(t *testing.T) {
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"Count":5,"Items":["a","b"]}`))
+	}))
+	defer awsServer.Close()
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"Count":3,"Items":["a"]}`))
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, nil)
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+	w := httptest.NewRecorder()
+	cp.ServeHTTP(w, req)
+
+	results := cp.Results()
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Match)
+	assert.NotEmpty(t, results[0].Diffs, "body diffs should be captured")
+	assert.Equal(t, "data", results[0].Severity)
+}
+
+func TestContract_Report(t *testing.T) {
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer awsServer.Close()
+
+	// CloudMock matches on first request, mismatches on second.
+	var cmCount int32
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&cmCount, 1)
+		if n == 1 {
+			w.WriteHeader(200)
+			w.Write([]byte(`{"ok":true}`))
+		} else {
+			w.WriteHeader(200)
+			w.Write([]byte(`{"ok":false}`))
+		}
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, nil)
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+		req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+		w := httptest.NewRecorder()
+		cp.ServeHTTP(w, req)
+	}
+
+	report := cp.Report()
+	assert.Equal(t, 2, report.TotalRequests)
+	assert.Equal(t, 1, report.Matched)
+	assert.Equal(t, 1, report.Mismatched)
+	assert.Equal(t, 50.0, report.CompatibilityPct)
+	assert.Len(t, report.Mismatches, 1)
+
+	// Verify by-service breakdown.
+	sr, ok := report.ByService["dynamodb"]
+	require.True(t, ok, "should have dynamodb service report")
+	assert.Equal(t, 2, sr.Total)
+	assert.Equal(t, 1, sr.Matched)
+	assert.Equal(t, 50.0, sr.Pct)
+
+	// Verify JSON serialisation round-trips.
+	data, err := json.Marshal(report)
+	require.NoError(t, err)
+	var decoded ContractReport
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, report.TotalRequests, decoded.TotalRequests)
+}
+
+func TestContract_IgnorePaths(t *testing.T) {
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"Items":[],"RequestId":"aws-123","ResponseMetadata":{"RequestId":"aws-123"}}`))
+	}))
+	defer awsServer.Close()
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"Items":[],"RequestId":"cm-456","ResponseMetadata":{"RequestId":"cm-456"}}`))
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, []string{"RequestId", "ResponseMetadata"})
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+	w := httptest.NewRecorder()
+	cp.ServeHTTP(w, req)
+
+	results := cp.Results()
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Match, "should match when only ignored paths differ")
+}
+
+func TestContract_Concurrent(t *testing.T) {
+	awsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer awsServer.Close()
+	cmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer cmServer.Close()
+
+	cp := NewContractProxy("us-east-1", cmServer.URL, nil)
+	cp.awsProxy.testEndpoint = awsServer.URL
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest("POST", "/", strings.NewReader(`{}`))
+			req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/dynamodb/aws4_request")
+			req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+			w := httptest.NewRecorder()
+			cp.ServeHTTP(w, req)
+		}()
+	}
+	wg.Wait()
+
+	results := cp.Results()
+	assert.Len(t, results, n, "all concurrent requests should be recorded")
+
+	report := cp.Report()
+	assert.Equal(t, n, report.TotalRequests)
+	assert.Equal(t, n, report.Matched)
+	assert.Equal(t, 100.0, report.CompatibilityPct)
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -54,12 +54,13 @@ var serviceEndpoints = map[string]string{
 // AWSProxy is a reverse proxy that forwards requests to real AWS endpoints
 // and captures the request/response pairs as CapturedEntry values.
 type AWSProxy struct {
-	entries    []*traffic.CapturedEntry
-	mu         sync.Mutex
-	startTime  time.Time
-	httpClient *http.Client
-	region     string
-	entrySeq   int
+	entries      []*traffic.CapturedEntry
+	mu           sync.Mutex
+	startTime    time.Time
+	httpClient   *http.Client
+	region       string
+	entrySeq     int
+	testEndpoint string // if set, all requests are forwarded here instead of real AWS
 }
 
 // New creates a new AWSProxy targeting the given AWS region.
@@ -84,12 +85,6 @@ func (p *AWSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	host := resolveEndpoint(svc, p.region)
-	if host == "" {
-		http.Error(w, fmt.Sprintf("unknown service: %s", svc), http.StatusBadGateway)
-		return
-	}
-
 	// Read request body.
 	var reqBody []byte
 	if r.Body != nil {
@@ -97,13 +92,27 @@ func (p *AWSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body.Close()
 	}
 
-	// Build the forwarding URL. Use HTTPS for real AWS endpoints, HTTP otherwise
-	// (e.g., local test servers).
-	scheme := "https"
-	if !strings.HasSuffix(host, ".amazonaws.com") {
-		scheme = "http"
+	// Build the forwarding URL.
+	var targetURL string
+	var host string
+	if p.testEndpoint != "" {
+		// Test mode: forward everything to the test endpoint.
+		targetURL = strings.TrimRight(p.testEndpoint, "/") + r.URL.RequestURI()
+		host = ""
+	} else {
+		host = resolveEndpoint(svc, p.region)
+		if host == "" {
+			http.Error(w, fmt.Sprintf("unknown service: %s", svc), http.StatusBadGateway)
+			return
+		}
+
+		// Use HTTPS for real AWS endpoints, HTTP otherwise (e.g., local test servers).
+		scheme := "https"
+		if !strings.HasSuffix(host, ".amazonaws.com") {
+			scheme = "http"
+		}
+		targetURL = fmt.Sprintf("%s://%s%s", scheme, host, r.URL.RequestURI())
 	}
-	targetURL := fmt.Sprintf("%s://%s%s", scheme, host, r.URL.RequestURI())
 
 	fwdReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, bytes.NewReader(reqBody))
 	if err != nil {
@@ -117,8 +126,10 @@ func (p *AWSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			fwdReq.Header.Add(k, v)
 		}
 	}
-	// Override Host to the real AWS endpoint.
-	fwdReq.Host = host
+	// Override Host to the real AWS endpoint (skip in test mode).
+	if host != "" {
+		fwdReq.Host = host
+	}
 
 	resp, err := p.httpClient.Do(fwdReq)
 	if err != nil {

--- a/website/src/content/docs/docs/guides/contract-testing.md
+++ b/website/src/content/docs/docs/guides/contract-testing.md
@@ -1,0 +1,180 @@
+---
+title: Contract Testing
+description: Validate CloudMock fidelity against real AWS with the dual-mode contract proxy
+---
+
+Contract testing sends every request to both real AWS and CloudMock simultaneously, compares the responses, and produces a compatibility report. This lets you prove that CloudMock behaves identically to real AWS for your specific workload -- without maintaining separate test suites.
+
+## Why contract testing
+
+Unit tests verify your application logic. Integration tests verify that your code works with CloudMock. Contract tests close the remaining gap: they verify that **CloudMock itself** returns the same responses as real AWS for the exact API calls your application makes.
+
+This is especially useful when:
+- Upgrading CloudMock versions and wanting to confirm nothing regressed
+- Onboarding a new AWS service and verifying coverage
+- Running in CI to catch fidelity issues before they reach production
+
+## Quick start
+
+Start a CloudMock instance and the contract proxy:
+
+```bash
+# Terminal 1: Start CloudMock
+npx cloudmock
+
+# Terminal 2: Start the contract proxy
+cloudmock contract \
+  --cloudmock http://localhost:4566 \
+  --port 4577 \
+  --output report.json
+```
+
+Point your application or tests at the contract proxy:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4577
+npm test
+```
+
+Press `Ctrl+C` to stop the proxy. The compatibility report is written to `report.json`.
+
+## The --run flag
+
+For CI pipelines, use `--run` to execute a command automatically. The proxy starts, runs the command with `AWS_ENDPOINT_URL` set, and exits with code 0 if all responses match or 1 if there are mismatches:
+
+```bash
+cloudmock contract \
+  --cloudmock http://localhost:4566 \
+  --port 4577 \
+  --output report.json \
+  --run "npm test"
+```
+
+The `AWS_ENDPOINT_URL` environment variable is automatically set to the proxy address (`http://localhost:4577`) for the child process.
+
+## Ignoring known differences
+
+Some fields differ between real AWS and CloudMock by design -- for example `RequestId` values and `ResponseMetadata` timestamps. Use `--ignore-paths` to exclude them from comparison:
+
+```bash
+cloudmock contract \
+  --ignore-paths RequestId,ResponseMetadata,Date \
+  --run "npm test"
+```
+
+Paths are matched by JSON key name at any nesting depth. For example, `RequestId` ignores both a top-level `RequestId` and `ResponseMetadata.RequestId`.
+
+## Reading the compatibility report
+
+The report is a JSON file with this structure:
+
+```json
+{
+  "started_at": "2026-04-01T10:00:00Z",
+  "duration_sec": 12.5,
+  "total_requests": 47,
+  "matched": 45,
+  "mismatched": 2,
+  "compatibility_pct": 95.7,
+  "by_service": {
+    "dynamodb": { "total": 30, "matched": 30, "pct": 100 },
+    "s3": { "total": 17, "matched": 15, "pct": 88.2 }
+  },
+  "mismatches": [
+    {
+      "service": "s3",
+      "action": "PutObject",
+      "aws_status": 200,
+      "cloudmock_status": 200,
+      "diffs": ["ETag: \"abc123\" -> \"def456\""],
+      "severity": "data"
+    }
+  ]
+}
+```
+
+**Severity levels:**
+- `status` -- HTTP status codes differ (most critical)
+- `schema` -- response structure differs (missing or extra keys)
+- `data` -- values differ but structure is the same
+- `error` -- one side returned an error or was unreachable
+
+## CI integration with GitHub Actions
+
+```yaml
+name: Contract Tests
+on: [push]
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: viridian-inc/cloudmock-action@v1
+
+      - name: Run contract tests
+        run: |
+          cloudmock contract \
+            --cloudmock http://localhost:4566 \
+            --port 4577 \
+            --output contract-report.json \
+            --ignore-paths RequestId,ResponseMetadata \
+            --run "npm test"
+        env:
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_DEFAULT_REGION: us-east-1
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-report
+          path: contract-report.json
+```
+
+The job fails if any API responses diverge between real AWS and CloudMock, giving you a clear signal in CI.
+
+## Go SDK contract test helper
+
+You can also use the contract proxy programmatically in Go tests:
+
+```go
+package myapp_test
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/neureaux/cloudmock/pkg/proxy"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestAWSCompatibility(t *testing.T) {
+    cp := proxy.NewContractProxy("us-east-1", "http://localhost:4566", []string{
+        "RequestId", "ResponseMetadata",
+    })
+    srv := httptest.NewServer(cp)
+    defer srv.Close()
+
+    // Point your AWS SDK at srv.URL and run your tests...
+
+    report := cp.Report()
+    assert.Equal(t, 100.0, report.CompatibilityPct,
+        "CloudMock should match real AWS for all requests")
+}
+```
+
+## CLI reference
+
+```
+cloudmock contract [options]
+
+Options:
+  --cloudmock URL       CloudMock endpoint (default: http://localhost:4566)
+  --region REGION       AWS region (default: us-east-1)
+  --port PORT           Local proxy port (default: 4577)
+  --output PATH         Report output path (default: contract-report.json)
+  --ignore-paths PATHS  Comma-separated JSON paths to ignore (default: RequestId,ResponseMetadata)
+  --run COMMAND         Execute command with proxy, then exit
+```

--- a/website/src/content/docs/docs/reference/comparison.md
+++ b/website/src/content/docs/docs/reference/comparison.md
@@ -28,6 +28,7 @@ This page compares CloudMock with other popular AWS emulation and mocking tools.
 | **Persistence** | Snapshot, DuckDB, PostgreSQL | Pro tier (persistence) | In-memory only | In-memory only |
 | **State snapshots** | Built-in — export/import JSON, commit to git, `--state` flag on startup | Cloud Pods (Pro tier only) | No equivalent | No equivalent |
 | **Traffic recording & replay** | Built-in (proxy + Go SDK interceptor, validate subcommand) | No | No | No |
+| **Contract testing** | Built-in (dual-mode proxy compares real AWS vs CloudMock live) | No | No | No |
 | **GitHub Action** | `viridian-inc/cloudmock-action@v1` — one-line CI setup | Yes (localstack-action) | No | No |
 | **Scaffolding CLI** | `create-cloudmock-app` — 9 templates (Node/Python/Go/Java/Rust) | No | No | No |
 | **Multi-account** | Single account (configurable ID) | Pro tier | In-process mocking | Single account |


### PR DESCRIPTION
Sends each request to both real AWS and CloudMock simultaneously, diffs responses, generates compatibility report. 8 new tests, full docs, CLI subcommand.