### PR TITLE
OpenTelemetry auto-instrumentation: always-on tracing with W3C traceparent

### DIFF
--- a/npm/cloudmock/README.md
+++ b/npm/cloudmock/README.md
@@ -31,6 +31,10 @@ npx cloudmock
 aws --endpoint-url=http://localhost:4566 s3 ls
 ```
 
+## Distributed Tracing
+
+Every request is automatically traced with W3C-compatible trace and span IDs. Incoming `traceparent` headers are propagated, and responses include `traceparent`, `X-Cloudmock-Trace-Id`, and `X-Cloudmock-Span-Id` headers. View traces in the DevTools UI at `http://localhost:4500`.
+
 ## SDKs
 
 Native SDK adapters for Go, Node.js, Python, Java, Rust, and Ruby with trace propagation and devtools integration. Any language works via HTTP.

--- a/pkg/gateway/logging.go
+++ b/pkg/gateway/logging.go
@@ -353,27 +353,39 @@ func LoggingMiddlewareWithOpts(next http.Handler, log *RequestLog, stats *Reques
 
 		start := time.Now()
 
-		// Extract or generate trace ID. Span ID is only needed when a trace store
-		// or broadcaster/production mode is active; skip the random generation otherwise.
-		traceID := r.Header.Get("X-Cloudmock-Trace-Id")
+		// Parse W3C traceparent header for trace context propagation.
+		// Format: "00-{32hex traceId}-{16hex parentSpanId}-{2hex flags}"
+		var traceID string
+		var parentSpanID string
+		if tp := r.Header.Get("traceparent"); tp != "" {
+			parts := strings.Split(tp, "-")
+			if len(parts) == 4 && parts[0] == "00" && len(parts[1]) == 32 && len(parts[2]) == 16 {
+				traceID = parts[1]
+				parentSpanID = parts[2]
+			}
+		}
+
+		// Fall back to CloudMock/AWS trace headers if no valid traceparent.
+		if traceID == "" {
+			traceID = r.Header.Get("X-Cloudmock-Trace-Id")
+		}
 		if traceID == "" {
 			traceID = r.Header.Get("X-Amz-Trace-Id")
 		}
 		if traceID == "" {
 			traceID = GenerateTraceID()
 		}
-		var spanID string
-		var parentSpanID string
-		if hasTraceStore || hasBroadcaster || productionMode {
-			spanID = GenerateSpanID()
+
+		// Always generate a span ID for every request.
+		spanID := GenerateSpanID()
+		if parentSpanID == "" {
 			parentSpanID = r.Header.Get("X-Cloudmock-Parent-Span-Id")
 		}
 
 		// Set trace headers on the response so callers can correlate.
 		w.Header().Set("X-Cloudmock-Trace-Id", traceID)
-		if spanID != "" {
-			w.Header().Set("X-Cloudmock-Span-Id", spanID)
-		}
+		w.Header().Set("X-Cloudmock-Span-Id", spanID)
+		w.Header().Set("traceparent", fmt.Sprintf("00-%s-%s-01", traceID, spanID))
 
 		// Capture request headers — only when we have subscribers that need them.
 		var reqHeaders map[string]string
@@ -470,7 +482,7 @@ func LoggingMiddlewareWithOpts(next http.Handler, log *RequestLog, stats *Reques
 				_ = opts.DataPlane.RequestW.Write(r.Context(), dpEntry)
 			}
 
-			// Emit an OTel span for each request.
+			// Emit an OTel span for each request (production only).
 			tracer := otel.Tracer("cloudmock-gateway")
 			_, span := tracer.Start(r.Context(), fmt.Sprintf("%s %s", r.Method, svcName))
 			span.SetAttributes(
@@ -497,46 +509,46 @@ func LoggingMiddlewareWithOpts(next http.Handler, log *RequestLog, stats *Reques
 				stats.Increment(svcName)
 			}
 
-			// Store trace context.
-			if hasTraceStore {
-				endTime := time.Now()
-				// Capture distributed context from headers
-				metadata := extractTraceMetadata(r)
-
-				// Capture call stacks only when explicitly enabled — it's expensive
-				// (~15μs: runtime.Callers + frame iteration + json.Marshal per request).
-				if captureStacks {
-					stacks := []profiling.SpanStack{profiling.CaptureStack("handler_entry", 2)}
-					stackJSON, _ := json.Marshal(stacks)
-					if metadata == nil {
-						metadata = make(map[string]string)
-					}
-					metadata["stacks"] = string(stackJSON)
-				}
-
-				trace := &TraceContext{
-					TraceID:      traceID,
-					SpanID:       spanID,
-					ParentSpanID: parentSpanID,
-					Service:      svcName,
-					Action:       action,
-					Method:       r.Method,
-					Path:         r.URL.Path,
-					StartTime:    start,
-					EndTime:      endTime,
-					Duration:     latency,
-					DurationMs:   latencyMs,
-					StatusCode:   rec.statusCode,
-					Error:        errMsg,
-					Metadata:     metadata,
-				}
-				opts.TraceStore.Add(trace)
-			}
-
 			// Record SLO metrics.
 			if hasSLO {
 				opts.SLOEngine.Record(svcName, action, latencyMs, rec.statusCode)
 			}
+		}
+
+		// Always store trace context when a trace store is available.
+		if hasTraceStore {
+			endTime := time.Now()
+			// Capture distributed context from headers
+			metadata := extractTraceMetadata(r)
+
+			// Capture call stacks only when explicitly enabled — it's expensive
+			// (~15μs: runtime.Callers + frame iteration + json.Marshal per request).
+			if captureStacks {
+				stacks := []profiling.SpanStack{profiling.CaptureStack("handler_entry", 2)}
+				stackJSON, _ := json.Marshal(stacks)
+				if metadata == nil {
+					metadata = make(map[string]string)
+				}
+				metadata["stacks"] = string(stackJSON)
+			}
+
+			trace := &TraceContext{
+				TraceID:      traceID,
+				SpanID:       spanID,
+				ParentSpanID: parentSpanID,
+				Service:      svcName,
+				Action:       action,
+				Method:       r.Method,
+				Path:         r.URL.Path,
+				StartTime:    start,
+				EndTime:      endTime,
+				Duration:     latency,
+				DurationMs:   latencyMs,
+				StatusCode:   rec.statusCode,
+				Error:        errMsg,
+				Metadata:     metadata,
+			}
+			opts.TraceStore.Add(trace)
 		}
 
 		// Broadcast request event for SSE clients — always runs regardless of mode.

--- a/pkg/gateway/traceid/traceid.go
+++ b/pkg/gateway/traceid/traceid.go
@@ -2,6 +2,7 @@
 package traceid
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/rand/v2"
 	"sync/atomic"
@@ -19,4 +20,45 @@ func New() string {
 	c := counter.Add(1)
 	rnd := rand.Uint64()
 	return fmt.Sprintf("%x-%x-%x", ts, rnd, c)
+}
+
+// GenerateW3CTraceID returns a 32-character hex string (16 random bytes)
+// compatible with the W3C Trace Context specification.
+func GenerateW3CTraceID() string {
+	var buf [16]byte
+	r1 := rand.Uint64()
+	r2 := rand.Uint64()
+	buf[0] = byte(r1 >> 56)
+	buf[1] = byte(r1 >> 48)
+	buf[2] = byte(r1 >> 40)
+	buf[3] = byte(r1 >> 32)
+	buf[4] = byte(r1 >> 24)
+	buf[5] = byte(r1 >> 16)
+	buf[6] = byte(r1 >> 8)
+	buf[7] = byte(r1)
+	buf[8] = byte(r2 >> 56)
+	buf[9] = byte(r2 >> 48)
+	buf[10] = byte(r2 >> 40)
+	buf[11] = byte(r2 >> 32)
+	buf[12] = byte(r2 >> 24)
+	buf[13] = byte(r2 >> 16)
+	buf[14] = byte(r2 >> 8)
+	buf[15] = byte(r2)
+	return hex.EncodeToString(buf[:])
+}
+
+// GenerateW3CSpanID returns a 16-character hex string (8 random bytes)
+// compatible with the W3C Trace Context specification.
+func GenerateW3CSpanID() string {
+	var buf [8]byte
+	r := rand.Uint64()
+	buf[0] = byte(r >> 56)
+	buf[1] = byte(r >> 48)
+	buf[2] = byte(r >> 40)
+	buf[3] = byte(r >> 32)
+	buf[4] = byte(r >> 24)
+	buf[5] = byte(r >> 16)
+	buf[6] = byte(r >> 8)
+	buf[7] = byte(r)
+	return hex.EncodeToString(buf[:])
 }

--- a/pkg/gateway/tracing.go
+++ b/pkg/gateway/tracing.go
@@ -234,12 +234,12 @@ func flattenSpans(t *TraceContext, traceStart time.Time, depth int, out *[]Timel
 	}
 }
 
-// GenerateTraceID returns a new unique trace ID.
+// GenerateTraceID returns a new unique W3C-compatible trace ID (32 hex chars).
 func GenerateTraceID() string {
-	return traceid.New()
+	return traceid.GenerateW3CTraceID()
 }
 
-// GenerateSpanID returns a new unique span ID.
+// GenerateSpanID returns a new unique W3C-compatible span ID (16 hex chars).
 func GenerateSpanID() string {
-	return traceid.New()
+	return traceid.GenerateW3CSpanID()
 }

--- a/pkg/gateway/tracing_integration_test.go
+++ b/pkg/gateway/tracing_integration_test.go
@@ -1,0 +1,152 @@
+package gateway_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/neureaux/cloudmock/pkg/config"
+	"github.com/neureaux/cloudmock/pkg/gateway"
+	"github.com/neureaux/cloudmock/pkg/routing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTracingGateway creates a gateway handler with a trace store wired up.
+func newTracingGateway(t *testing.T) (http.Handler, *gateway.TraceStore) {
+	t.Helper()
+	cfg := config.Default()
+	cfg.IAM.Mode = "none"
+
+	reg := routing.NewRegistry()
+	reg.Register(&echoService{})
+
+	gw := gateway.New(cfg, reg)
+	traceStore := gateway.NewTraceStore(100)
+
+	handler := gateway.LoggingMiddlewareWithOpts(gw, nil, nil, gateway.LoggingMiddlewareOpts{
+		TraceStore: traceStore,
+	})
+	return handler, traceStore
+}
+
+// s3Request builds a basic S3 ListBuckets request.
+func s3Request() *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/?Action=ListBuckets", nil)
+	req.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc123")
+	return req
+}
+
+func TestTracing_SpanCreated(t *testing.T) {
+	handler, _ := newTracingGateway(t)
+
+	req := s3Request()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.NotEmpty(t, w.Header().Get("X-Cloudmock-Trace-Id"), "response should have X-Cloudmock-Trace-Id")
+	assert.NotEmpty(t, w.Header().Get("X-Cloudmock-Span-Id"), "response should have X-Cloudmock-Span-Id")
+}
+
+func TestTracing_TraceparentPropagated(t *testing.T) {
+	handler, _ := newTracingGateway(t)
+
+	incomingTraceID := "abcdef1234567890abcdef1234567890"
+	incomingSpanID := "1234567890abcdef"
+	traceparent := "00-" + incomingTraceID + "-" + incomingSpanID + "-01"
+
+	req := s3Request()
+	req.Header.Set("traceparent", traceparent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// The response trace ID should match the incoming trace ID.
+	assert.Equal(t, incomingTraceID, w.Header().Get("X-Cloudmock-Trace-Id"),
+		"trace ID should be propagated from traceparent")
+
+	// The span ID should be different (CloudMock generates a new one for this span).
+	respSpanID := w.Header().Get("X-Cloudmock-Span-Id")
+	assert.NotEmpty(t, respSpanID)
+	assert.NotEqual(t, incomingSpanID, respSpanID,
+		"span ID should be a new one, not the parent span ID")
+
+	// The response traceparent should use the same trace ID but a new span ID.
+	respTP := w.Header().Get("traceparent")
+	require.NotEmpty(t, respTP)
+	parts := strings.Split(respTP, "-")
+	require.Len(t, parts, 4)
+	assert.Equal(t, "00", parts[0])
+	assert.Equal(t, incomingTraceID, parts[1])
+	assert.Equal(t, respSpanID, parts[2])
+	assert.Equal(t, "01", parts[3])
+}
+
+func TestTracing_ResponseHeaders(t *testing.T) {
+	handler, _ := newTracingGateway(t)
+
+	req := s3Request()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Validate traceparent format: 00-{32hex}-{16hex}-01
+	tp := w.Header().Get("traceparent")
+	require.NotEmpty(t, tp, "response should have traceparent header")
+
+	re := regexp.MustCompile(`^00-[0-9a-f]{32}-[0-9a-f]{16}-01$`)
+	assert.Regexp(t, re, tp, "traceparent should be valid W3C format")
+}
+
+func TestTracing_SpanAttributes(t *testing.T) {
+	handler, traceStore := newTracingGateway(t)
+
+	req := s3Request()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	traceID := w.Header().Get("X-Cloudmock-Trace-Id")
+	require.NotEmpty(t, traceID)
+
+	trace := traceStore.Get(traceID)
+	require.NotNil(t, trace, "trace should be in the store")
+	assert.Equal(t, "s3", trace.Service)
+	assert.Equal(t, "ListBuckets", trace.Action)
+	assert.Equal(t, http.MethodGet, trace.Method)
+	assert.Equal(t, http.StatusOK, trace.StatusCode)
+}
+
+func TestTracing_TraceStorePopulated(t *testing.T) {
+	handler, traceStore := newTracingGateway(t)
+
+	// Make multiple requests.
+	for i := 0; i < 5; i++ {
+		req := s3Request()
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	recent := traceStore.Recent("", nil, 10)
+	assert.Len(t, recent, 5, "trace store should have 5 entries")
+}
+
+func TestTracing_AlwaysOnWithoutTraceStore(t *testing.T) {
+	// Even without a trace store, response headers should include trace/span IDs.
+	cfg := config.Default()
+	cfg.IAM.Mode = "none"
+	reg := routing.NewRegistry()
+	reg.Register(&echoService{})
+	gw := gateway.New(cfg, reg)
+
+	// Use basic logging middleware without trace store.
+	handler := gateway.LoggingMiddleware(gw, gateway.NewRequestLog(10), gateway.NewRequestStats())
+
+	req := s3Request()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.NotEmpty(t, w.Header().Get("X-Cloudmock-Trace-Id"))
+	assert.NotEmpty(t, w.Header().Get("X-Cloudmock-Span-Id"))
+	assert.NotEmpty(t, w.Header().Get("traceparent"))
+}

--- a/sdk/cloudmock.go
+++ b/sdk/cloudmock.go
@@ -35,6 +35,7 @@ type options struct {
 	iamMode   string
 	region    string
 	accountID string
+	tracing   bool
 }
 
 // WithProfile sets the service profile ("minimal" or "standard").
@@ -49,6 +50,11 @@ func WithRegion(r string) Option { return func(o *options) { o.region = r } }
 // WithAccountID sets the AWS account ID for the mock.
 func WithAccountID(id string) Option { return func(o *options) { o.accountID = id } }
 
+// WithTracing enables always-on distributed tracing with W3C traceparent propagation.
+// When enabled, a TraceStore is created and wired to the gateway, and the in-process
+// transport propagates trace context from the Go context as traceparent headers.
+func WithTracing() Option { return func(o *options) { o.tracing = true } }
+
 // CloudMock is an in-process AWS mock. All AWS SDK calls routed through its
 // Config() go directly to the gateway handler with zero network overhead.
 type CloudMock struct {
@@ -56,6 +62,7 @@ type CloudMock struct {
 	transport    *inProcessTransport
 	cfg          aws.Config
 	chaosEngine  *gateway.ChaosEngine
+	traceStore   *gateway.TraceStore
 }
 
 // New creates a new in-process CloudMock instance. By default it uses a
@@ -108,6 +115,15 @@ func New(opts ...Option) *CloudMock {
 	chaosEngine := gateway.NewChaosEngine()
 	var handler http.Handler = gateway.ChaosMiddleware(gw, chaosEngine)
 
+	// When tracing is enabled, wrap with logging middleware that populates the trace store.
+	var traceStore *gateway.TraceStore
+	if o.tracing {
+		traceStore = gateway.NewTraceStore(500)
+		handler = gateway.LoggingMiddlewareWithOpts(handler, nil, nil, gateway.LoggingMiddlewareOpts{
+			TraceStore: traceStore,
+		})
+	}
+
 	transport := newInProcessTransport(handler)
 
 	// Build the aws.Config that the caller will pass to SDK clients.
@@ -134,12 +150,18 @@ func New(opts ...Option) *CloudMock {
 		transport:   transport,
 		cfg:         awsConfig,
 		chaosEngine: chaosEngine,
+		traceStore:  traceStore,
 	}
 }
 
 // Config returns an aws.Config that routes all SDK calls through CloudMock in-process.
 func (cm *CloudMock) Config() aws.Config {
 	return cm.cfg
+}
+
+// TraceStore returns the trace store if tracing is enabled, or nil otherwise.
+func (cm *CloudMock) TraceStore() *gateway.TraceStore {
+	return cm.traceStore
 }
 
 // Close releases resources held by this CloudMock instance.

--- a/sdk/cloudmock_test.go
+++ b/sdk/cloudmock_test.go
@@ -755,6 +755,58 @@ func BenchmarkInProcess_S3_PutObject(b *testing.B) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Tracing tests
+// ---------------------------------------------------------------------------
+
+func TestSDK_WithTracing(t *testing.T) {
+	cm := New(WithTracing())
+	defer cm.Close()
+
+	require.NotNil(t, cm.TraceStore(), "TraceStore should be non-nil when tracing is enabled")
+
+	client := s3.NewFromConfig(cm.Config(), func(o *s3.Options) { o.UsePathStyle = true })
+
+	// Make an S3 call.
+	_, _ = client.ListBuckets(ctx, &s3.ListBucketsInput{})
+
+	// The trace store should have at least one entry.
+	recent := cm.TraceStore().Recent("", nil, 10)
+	require.NotEmpty(t, recent, "trace store should have entries after S3 call")
+
+	// Verify the trace has S3 service.
+	found := false
+	for _, tr := range recent {
+		if tr.RootService == "s3" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected at least one S3 trace")
+}
+
+func TestSDK_WithTracing_Disabled(t *testing.T) {
+	cm := New() // no WithTracing
+	defer cm.Close()
+
+	assert.Nil(t, cm.TraceStore(), "TraceStore should be nil when tracing is not enabled")
+}
+
+func TestSDK_WithTracing_MultipleRequests(t *testing.T) {
+	cm := New(WithTracing())
+	defer cm.Close()
+
+	client := s3.NewFromConfig(cm.Config(), func(o *s3.Options) { o.UsePathStyle = true })
+
+	// Make a few calls.
+	_, _ = client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	_, _ = client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("trace-test-bucket")})
+	_, _ = client.ListBuckets(ctx, &s3.ListBucketsInput{})
+
+	recent := cm.TraceStore().Recent("", nil, 10)
+	assert.GreaterOrEqual(t, len(recent), 3, "trace store should have at least 3 entries")
+}
+
 func BenchmarkInProcess_SQS_SendMessage(b *testing.B) {
 	cm := New()
 	defer cm.Close()

--- a/sdk/transport.go
+++ b/sdk/transport.go
@@ -2,11 +2,15 @@ package sdk
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // serviceFromTarget extracts the service name from the X-Amz-Target header.
@@ -166,6 +170,13 @@ func (t *inProcessTransport) RoundTrip(req *http.Request) (*http.Response, error
 		}
 	}
 
+	// Propagate W3C traceparent from Go context if present (set by OTel SDK).
+	if req.Header.Get("traceparent") == "" {
+		if tp := extractTraceparentFromContext(req.Context()); tp != "" {
+			req.Header.Set("traceparent", tp)
+		}
+	}
+
 	// Get a pooled recorder and reset it for reuse.
 	rec := t.recorderPool.Get().(*httptest.ResponseRecorder)
 	rec.Body.Reset()
@@ -239,3 +250,13 @@ type nopReadCloser struct {
 }
 
 func (nopReadCloser) Close() error { return nil }
+
+// extractTraceparentFromContext checks for an OTel span in the context and
+// returns a W3C traceparent string if one is active, or empty string otherwise.
+func extractTraceparentFromContext(ctx context.Context) string {
+	// Use the OTel propagation API to extract trace context.
+	// This avoids a direct dependency on the OTel trace package internals.
+	carrier := make(propagation.HeaderCarrier)
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	return carrier.Get("traceparent")
+}

--- a/website/src/content/docs/docs/guides/tracing.md
+++ b/website/src/content/docs/docs/guides/tracing.md
@@ -1,0 +1,119 @@
+---
+title: Distributed Tracing
+description: Auto-instrumented tracing with W3C traceparent propagation
+---
+
+CloudMock automatically generates a trace span for every request. No configuration is required -- tracing is always on.
+
+## How it works
+
+Every request that passes through the CloudMock gateway receives:
+
+- A **Trace ID** (W3C-compatible, 32-character hex string)
+- A **Span ID** (W3C-compatible, 16-character hex string)
+- Response headers: `X-Cloudmock-Trace-Id`, `X-Cloudmock-Span-Id`, and `traceparent`
+
+Traces are stored in an in-memory trace store and displayed in the DevTools Traces view.
+
+## Viewing traces in DevTools
+
+Open the DevTools UI at [http://localhost:4500](http://localhost:4500) and navigate to the **Traces** tab. You will see a list of all recent traces with waterfall and flamegraph views. See the [Traces View](/docs/devtools/traces/) documentation for details.
+
+## W3C traceparent propagation
+
+CloudMock implements the [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification. If your application sends a `traceparent` header, CloudMock will:
+
+1. **Parse** the incoming trace ID and parent span ID
+2. **Preserve** the trace ID across the request
+3. **Generate** a new span ID for the CloudMock span
+4. **Return** an updated `traceparent` header in the response
+
+### traceparent format
+
+```
+traceparent: 00-{32-char-hex-trace-id}-{16-char-hex-span-id}-01
+```
+
+### Example
+
+Send a request with a traceparent header:
+
+```bash
+curl -H "traceparent: 00-abcdef1234567890abcdef1234567890-1234567890abcdef-01" \
+     http://localhost:4566/my-bucket
+```
+
+The response will include:
+
+```
+traceparent: 00-abcdef1234567890abcdef1234567890-<new-span-id>-01
+X-Cloudmock-Trace-Id: abcdef1234567890abcdef1234567890
+X-Cloudmock-Span-Id: <new-span-id>
+```
+
+The trace ID is preserved from the incoming request. The span ID is always new, representing CloudMock's span in the trace.
+
+## Connecting to Jaeger or Zipkin
+
+In production mode, CloudMock emits OpenTelemetry spans via the OTel SDK. Configure the OTLP exporter to send spans to your collector:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+cloudmock --production
+```
+
+This sends spans to any OpenTelemetry-compatible backend (Jaeger, Zipkin, Datadog, Honeycomb, etc.).
+
+## Go SDK tracing
+
+The Go SDK supports tracing via the `WithTracing()` option:
+
+```go
+import "github.com/neureaux/cloudmock/sdk"
+
+cm := sdk.New(sdk.WithTracing())
+defer cm.Close()
+
+// All AWS SDK calls through cm.Config() are now traced.
+client := s3.NewFromConfig(cm.Config(), func(o *s3.Options) {
+    o.UsePathStyle = true
+})
+
+client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+
+// Access the trace store programmatically.
+traces := cm.TraceStore().Recent("", nil, 10)
+fmt.Printf("Captured %d traces\n", len(traces))
+```
+
+When tracing is enabled, the SDK:
+
+- Creates an in-memory TraceStore and wires it to the gateway
+- Propagates `traceparent` headers from the Go context (if an OTel span is active)
+- Stores all spans for programmatic inspection in tests
+
+### Example: trace a request through your app and CloudMock
+
+```go
+func TestOrderWorkflow(t *testing.T) {
+    cm := sdk.New(sdk.WithTracing())
+    defer cm.Close()
+
+    ddb := dynamodb.NewFromConfig(cm.Config())
+    s3c := s3.NewFromConfig(cm.Config(), func(o *s3.Options) { o.UsePathStyle = true })
+
+    // Your application code makes AWS calls...
+    s3c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("orders")})
+    ddb.CreateTable(ctx, &dynamodb.CreateTableInput{
+        TableName: aws.String("orders"),
+        // ...
+    })
+
+    // Inspect traces to verify your app's AWS call patterns.
+    traces := cm.TraceStore().Recent("", nil, 50)
+    for _, tr := range traces {
+        t.Logf("trace=%s service=%s action=%s duration=%.2fms",
+            tr.TraceID, tr.RootService, tr.RootAction, tr.DurationMs)
+    }
+}
+```

--- a/website/src/content/docs/docs/reference/comparison.md
+++ b/website/src/content/docs/docs/reference/comparison.md
@@ -19,7 +19,7 @@ This page compares CloudMock with other popular AWS emulation and mocking tools.
 | **Docker required** | No (optional) | Yes (for many services) | No | Yes (for Lambda) |
 | **In-process mode** | Yes (Go only, ~20 μs/op) | No | Yes (Python only) | No |
 | **Devtools UI** | Yes -- 12-view desktop app (topology, traces, metrics, chaos, etc.) | Yes -- web dashboard (Pro) | No | No |
-| **Distributed tracing** | Built-in (waterfall + flamegraph) | Pro tier only | No | Limited (X-Ray local) |
+| **Distributed tracing** | Built-in always-on (W3C traceparent, waterfall + flamegraph) | Pro tier only | No | Limited (X-Ray local) |
 | **Chaos engineering** | Built-in (latency, errors, throttling) | No | No | No |
 | **IAM emulation** | Full policy evaluation with enforce/authenticate/none modes | Pro tier only | Partial | No |
 | **Pricing** | Free and open source | Free tier + Pro ($35/mo) + Team + Enterprise | Free and open source | Free and open source |


### PR DESCRIPTION
Every request gets a trace span. W3C traceparent propagation. TraceStore populated in all modes. 9 new tests, guide, SDK WithTracing option.