### PR TITLE
CloudTrail event replay: recreate production state from audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,25 @@ cloudmock record --output prod-traffic.json    # proxy mode: captures real AWS c
 cloudmock validate --input prod-traffic.json   # replay + compare, exit 0 = all match
 ```
 
+## CloudTrail Event Replay
+
+Recreate production AWS state from CloudTrail audit logs:
+
+```bash
+# Export CloudTrail events from AWS
+aws cloudtrail lookup-events --start-time 2026-03-01 --output json > trail.json
+
+# Replay write operations against CloudMock
+cloudmock cloudtrail replay --input trail.json --endpoint http://localhost:4566
+```
+
+Filter by service, control replay speed, or use the admin API:
+
+```bash
+cloudmock cloudtrail replay --input trail.json --services dynamodb,s3 --speed 0
+curl -X POST http://localhost:4599/api/cloudtrail/replay -d @trail.json
+```
+
 ## Comparison
 
 | Feature | CloudMock | LocalStack (Free) | Moto |

--- a/cmd/cloudmock/main.go
+++ b/cmd/cloudmock/main.go
@@ -13,7 +13,9 @@ import (
 	"os/signal"
 	"strings"
 	"text/tabwriter"
+	"time"
 
+	"github.com/neureaux/cloudmock/pkg/cloudtrail"
 	"github.com/neureaux/cloudmock/pkg/proxy"
 	"github.com/neureaux/cloudmock/pkg/traffic"
 )
@@ -54,6 +56,13 @@ func main() {
 		cmdValidate(adminAddr, os.Args[2:])
 	case "contract":
 		cmdContract(os.Args[2:])
+	case "cloudtrail":
+		if len(os.Args) > 2 && os.Args[2] == "replay" {
+			cmdCloudTrailReplay(os.Args[3:])
+		} else {
+			fmt.Fprintln(os.Stderr, "Usage: cloudmock cloudtrail replay [options]")
+			os.Exit(1)
+		}
 	case "version":
 		cmdVersion()
 	case "config":
@@ -71,18 +80,19 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, `Usage: cloudmock <command> [options]
 
 Commands:
-  start      Start the cloudmock gateway
-  stop       Stop the cloudmock gateway
-  status     Show health status of all services
-  reset      Reset service state (all or specific)
-  services   List registered services
-  record     Record real AWS traffic via proxy
-  replay     Replay a recording against CloudMock
-  validate   Replay + compare + exit code (CI mode)
-  contract   Dual-mode proxy: compare real AWS vs CloudMock live
-  config     Show current configuration
-  version    Print version information
-  help       Show this help message
+  start              Start the cloudmock gateway
+  stop               Stop the cloudmock gateway
+  status             Show health status of all services
+  reset              Reset service state (all or specific)
+  services           List registered services
+  record             Record real AWS traffic via proxy
+  replay             Replay a recording against CloudMock
+  validate           Replay + compare + exit code (CI mode)
+  contract           Dual-mode proxy: compare real AWS vs CloudMock live
+  cloudtrail replay  Replay CloudTrail events to recreate state
+  config             Show current configuration
+  version            Print version information
+  help               Show this help message
 
 Use "cloudmock <command> --help" for more information about a command.`)
 }
@@ -604,4 +614,71 @@ func printContractSummary(report *proxy.ContractReport, outputPath string) {
 	}
 
 	fmt.Printf("\nReport written to %s\n", outputPath)
+}
+
+func cmdCloudTrailReplay(args []string) {
+	fs := flag.NewFlagSet("cloudtrail replay", flag.ExitOnError)
+	input := fs.String("input", "", "path to CloudTrail JSON file (required)")
+	endpoint := fs.String("endpoint", "http://localhost:4566", "CloudMock gateway endpoint")
+	speed := fs.Float64("speed", 0, "replay speed (0 = instant, 1.0 = realtime)")
+	services := fs.String("services", "", "comma-separated list of services to replay")
+	output := fs.String("output", "", "path to write result JSON")
+	fs.Parse(args)
+
+	if *input == "" {
+		fmt.Fprintln(os.Stderr, "Error: --input is required")
+		os.Exit(1)
+	}
+
+	events, err := cloudtrail.ParseFile(*input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading CloudTrail file: %v\n", err)
+		os.Exit(1)
+	}
+
+	var svcFilter []string
+	if *services != "" {
+		for _, s := range strings.Split(*services, ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				svcFilter = append(svcFilter, s)
+			}
+		}
+	}
+
+	cfg := cloudtrail.ReplayConfig{
+		Endpoint:    *endpoint,
+		Speed:       *speed,
+		FilterWrite: true,
+		Services:    svcFilter,
+	}
+
+	fmt.Printf("Replaying %d CloudTrail events against %s\n", len(events), *endpoint)
+
+	result, err := cloudtrail.Replay(events, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nCloudTrail Replay Results\n")
+	fmt.Printf("  Total events:  %d\n", result.TotalEvents)
+	fmt.Printf("  Replayed:      %d\n", result.Replayed)
+	fmt.Printf("  Skipped:       %d\n", result.Skipped)
+	fmt.Printf("  Succeeded:     %d\n", result.Succeeded)
+	fmt.Printf("  Failed:        %d\n", result.Failed)
+	fmt.Printf("  Duration:      %s\n", result.Duration.Round(time.Millisecond))
+
+	for _, e := range result.Errors {
+		fmt.Printf("  [FAIL] %s.%s: %s (status %d)\n", e.Service, e.EventName, e.Error, e.Status)
+	}
+
+	if *output != "" {
+		data, _ := json.MarshalIndent(result, "", "  ")
+		if err := os.WriteFile(*output, data, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing output: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("\nResults written to %s\n", *output)
+	}
 }

--- a/pkg/admin/api.go
+++ b/pkg/admin/api.go
@@ -15,6 +15,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
+	ctReplay "github.com/neureaux/cloudmock/pkg/cloudtrail"
 	"github.com/neureaux/cloudmock/pkg/annotations"
 	"github.com/neureaux/cloudmock/pkg/anomaly"
 	"github.com/neureaux/cloudmock/pkg/auth"
@@ -327,6 +328,9 @@ func New(cfg *config.Config, registry *routing.Registry, log *gateway.RequestLog
 	a.mux.HandleFunc("/api/state/import", a.handleStateImport)
 	a.mux.HandleFunc("/api/state/reset", a.handleStateReset)
 
+	// CloudTrail replay endpoint
+	a.mux.HandleFunc("/api/cloudtrail/replay", a.handleCloudTrailReplay)
+
 	a.seedDefaultDashboard()
 
 	return a
@@ -463,6 +467,9 @@ func NewWithDataPlane(cfg *config.Config, registry *routing.Registry, dp *datapl
 	a.mux.HandleFunc("/api/state/export", a.handleStateExport)
 	a.mux.HandleFunc("/api/state/import", a.handleStateImport)
 	a.mux.HandleFunc("/api/state/reset", a.handleStateReset)
+
+	// CloudTrail replay endpoint
+	a.mux.HandleFunc("/api/cloudtrail/replay", a.handleCloudTrailReplay)
 
 	a.seedDefaultDashboard()
 
@@ -4365,4 +4372,43 @@ func (a *API) handleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	a.stripeWebhook.HandleWebhook(w, r)
+}
+
+// handleCloudTrailReplay accepts a POST with CloudTrail JSON (Records array)
+// and replays the events against the local CloudMock gateway.
+func (a *API) handleCloudTrailReplay(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+	defer r.Body.Close()
+
+	events, err := ctReplay.ParseJSON(body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to parse CloudTrail JSON: "+err.Error())
+		return
+	}
+
+	endpoint := "http://localhost:4566"
+	if a.cfg != nil && a.cfg.Gateway.Port != 0 {
+		endpoint = fmt.Sprintf("http://localhost:%d", a.cfg.Gateway.Port)
+	}
+
+	result, err := ctReplay.Replay(events, ctReplay.ReplayConfig{
+		Endpoint:    endpoint,
+		Speed:       0,
+		FilterWrite: true,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "replay failed: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }

--- a/pkg/cloudtrail/converter.go
+++ b/pkg/cloudtrail/converter.go
@@ -1,0 +1,259 @@
+package cloudtrail
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Protocol types for AWS services.
+const (
+	protoJSON  = "json"
+	protoQuery = "query"
+	protoREST  = "rest"
+)
+
+// serviceProtocols maps service names to their wire protocol.
+var serviceProtocols = map[string]string{
+	"dynamodb":       protoJSON,
+	"kms":            protoJSON,
+	"kinesis":        protoJSON,
+	"logs":           protoJSON,
+	"lambda":         protoREST,
+	"sqs":            protoQuery,
+	"sns":            protoQuery,
+	"iam":            protoQuery,
+	"sts":            protoQuery,
+	"ec2":            protoQuery,
+	"autoscaling":    protoQuery,
+	"elasticloadbalancing": protoQuery,
+	"cloudformation": protoQuery,
+	"s3":             protoREST,
+}
+
+// targetPrefixes maps service names to the X-Amz-Target prefix used for JSON protocol services.
+var targetPrefixes = map[string]string{
+	"dynamodb": "DynamoDB_20120810",
+	"kms":      "TrentService",
+	"kinesis":  "Kinesis_20131202",
+	"logs":     "Logs_20140328",
+}
+
+// s3MethodMap maps S3 CloudTrail event names to HTTP methods.
+var s3MethodMap = map[string]string{
+	"CreateBucket":      "PUT",
+	"DeleteBucket":      "DELETE",
+	"PutObject":         "PUT",
+	"DeleteObject":      "DELETE",
+	"GetObject":         "GET",
+	"HeadObject":        "HEAD",
+	"HeadBucket":        "HEAD",
+	"ListBuckets":       "GET",
+	"ListObjects":       "GET",
+	"GetBucketLocation": "GET",
+}
+
+// lambdaPathMap maps Lambda CloudTrail event names to HTTP method + path patterns.
+var lambdaPathMap = map[string]struct {
+	method string
+	path   string // %s is replaced with function name from requestParameters
+}{
+	"CreateFunction20150331":  {"POST", "/2015-03-31/functions"},
+	"Invoke":                  {"POST", "/2015-03-31/functions/%s/invocations"},
+	"DeleteFunction20150331":  {"DELETE", "/2015-03-31/functions/%s"},
+	"GetFunction":             {"GET", "/2015-03-31/functions/%s"},
+	"ListFunctions":           {"GET", "/2015-03-31/functions"},
+	"UpdateFunctionCode20150331v2": {"PUT", "/2015-03-31/functions/%s/code"},
+}
+
+// supportedEvents lists the top events we handle. Unknown events return an error.
+var supportedEvents = map[string]bool{
+	// DynamoDB
+	"CreateTable": true, "DeleteTable": true, "PutItem": true, "GetItem": true, "UpdateItem": true,
+	// S3
+	"CreateBucket": true, "DeleteBucket": true, "PutObject": true, "DeleteObject": true, "GetObject": true,
+	// SQS
+	"CreateQueue": true, "SendMessage": true, "DeleteQueue": true,
+	// SNS
+	"CreateTopic": true, "Subscribe": true, "Publish": true,
+	// IAM
+	"CreateRole": true, "CreateUser": true,
+	// KMS
+	"CreateKey": true,
+	// Lambda
+	"CreateFunction20150331": true, "Invoke": true,
+	// CloudWatch Logs
+	"CreateLogGroup": true,
+	// Kinesis
+	"CreateStream": true,
+	// STS
+	"GetCallerIdentity": true,
+	// EC2
+	"RunInstances": true,
+	// CloudFormation
+	"CreateStack": true,
+}
+
+// ConvertToRequest converts a CloudTrail event into an HTTP request suitable for
+// sending to a CloudMock endpoint.
+func ConvertToRequest(event CloudTrailEvent, endpoint string) (*http.Request, error) {
+	svc := event.ServiceName()
+
+	proto, ok := serviceProtocols[svc]
+	if !ok {
+		return nil, fmt.Errorf("unsupported service: %s", svc)
+	}
+
+	if !supportedEvents[event.EventName] {
+		return nil, fmt.Errorf("unsupported event: %s.%s", svc, event.EventName)
+	}
+
+	var req *http.Request
+	var err error
+
+	switch proto {
+	case protoJSON:
+		req, err = buildJSONRequest(event, svc, endpoint)
+	case protoQuery:
+		req, err = buildQueryRequest(event, svc, endpoint)
+	case protoREST:
+		if svc == "s3" {
+			req, err = buildS3Request(event, endpoint)
+		} else if svc == "lambda" {
+			req, err = buildLambdaRequest(event, endpoint)
+		} else {
+			return nil, fmt.Errorf("unsupported REST service: %s", svc)
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Set fake Authorization header for gateway service detection.
+	region := event.AWSRegion
+	if region == "" {
+		region = "us-east-1"
+	}
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=test/20260101/%s/%s/aws4_request, SignedHeaders=host, Signature=fake",
+		region, svc))
+
+	// Set fast-route header for the gateway.
+	req.Header.Set("X-Cloudmock-Service", svc)
+
+	return req, nil
+}
+
+func buildJSONRequest(event CloudTrailEvent, svc, endpoint string) (*http.Request, error) {
+	prefix, ok := targetPrefixes[svc]
+	if !ok {
+		return nil, fmt.Errorf("no target prefix for JSON service: %s", svc)
+	}
+
+	body, err := json.Marshal(event.RequestParameters)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request parameters: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-Amz-Target", prefix+"."+event.EventName)
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+
+	return req, nil
+}
+
+func buildQueryRequest(event CloudTrailEvent, svc, endpoint string) (*http.Request, error) {
+	form := url.Values{}
+	form.Set("Action", event.EventName)
+
+	for k, v := range event.RequestParameters {
+		form.Set(k, fmt.Sprint(v))
+	}
+
+	body := form.Encode()
+	req, err := http.NewRequest("POST", endpoint, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req, nil
+}
+
+func buildS3Request(event CloudTrailEvent, endpoint string) (*http.Request, error) {
+	method, ok := s3MethodMap[event.EventName]
+	if !ok {
+		method = "GET"
+	}
+
+	bucket, _ := event.RequestParameters["bucketName"].(string)
+	key, _ := event.RequestParameters["key"].(string)
+
+	var reqURL string
+	switch {
+	case bucket != "" && key != "":
+		reqURL = endpoint + "/" + bucket + "/" + key
+	case bucket != "":
+		reqURL = endpoint + "/" + bucket
+	default:
+		reqURL = endpoint
+	}
+
+	var bodyReader *bytes.Reader
+	if method == "PUT" && key != "" {
+		// For PutObject, send a placeholder body.
+		bodyReader = bytes.NewReader([]byte("cloudtrail-replay-placeholder"))
+	} else {
+		bodyReader = bytes.NewReader(nil)
+	}
+
+	req, err := http.NewRequest(method, reqURL, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func buildLambdaRequest(event CloudTrailEvent, endpoint string) (*http.Request, error) {
+	mapping, ok := lambdaPathMap[event.EventName]
+	if !ok {
+		return nil, fmt.Errorf("unsupported Lambda event: %s", event.EventName)
+	}
+
+	funcName, _ := event.RequestParameters["functionName"].(string)
+
+	var path string
+	if strings.Contains(mapping.path, "%s") {
+		path = fmt.Sprintf(mapping.path, funcName)
+	} else {
+		path = mapping.path
+	}
+
+	var body []byte
+	if mapping.method == "POST" || mapping.method == "PUT" {
+		var err error
+		body, err = json.Marshal(event.RequestParameters)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(mapping.method, endpoint+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}

--- a/pkg/cloudtrail/converter_test.go
+++ b/pkg/cloudtrail/converter_test.go
@@ -1,0 +1,131 @@
+package cloudtrail
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvert_DynamoDB_CreateTable(t *testing.T) {
+	event := CloudTrailEvent{
+		EventSource: "dynamodb.amazonaws.com",
+		EventName:   "CreateTable",
+		AWSRegion:   "us-east-1",
+		RequestParameters: map[string]any{
+			"tableName": "Users",
+			"keySchema": []any{
+				map[string]any{"attributeName": "id", "keyType": "HASH"},
+			},
+		},
+	}
+
+	req, err := ConvertToRequest(event, "http://localhost:4566")
+	require.NoError(t, err)
+
+	assert.Equal(t, "POST", req.Method)
+	assert.Equal(t, "DynamoDB_20120810.CreateTable", req.Header.Get("X-Amz-Target"))
+	assert.Equal(t, "application/x-amz-json-1.0", req.Header.Get("Content-Type"))
+	assert.Contains(t, req.Header.Get("Authorization"), "dynamodb")
+
+	body, _ := io.ReadAll(req.Body)
+	var params map[string]any
+	err = json.Unmarshal(body, &params)
+	require.NoError(t, err)
+	assert.Equal(t, "Users", params["tableName"])
+}
+
+func TestConvert_S3_CreateBucket(t *testing.T) {
+	event := CloudTrailEvent{
+		EventSource:       "s3.amazonaws.com",
+		EventName:         "CreateBucket",
+		AWSRegion:         "us-east-1",
+		RequestParameters: map[string]any{"bucketName": "my-bucket"},
+	}
+
+	req, err := ConvertToRequest(event, "http://localhost:4566")
+	require.NoError(t, err)
+
+	assert.Equal(t, "PUT", req.Method)
+	assert.Equal(t, "http://localhost:4566/my-bucket", req.URL.String())
+	assert.Contains(t, req.Header.Get("Authorization"), "s3")
+}
+
+func TestConvert_SQS_CreateQueue(t *testing.T) {
+	event := CloudTrailEvent{
+		EventSource:       "sqs.amazonaws.com",
+		EventName:         "CreateQueue",
+		AWSRegion:         "us-east-1",
+		RequestParameters: map[string]any{"QueueName": "tasks"},
+	}
+
+	req, err := ConvertToRequest(event, "http://localhost:4566")
+	require.NoError(t, err)
+
+	assert.Equal(t, "POST", req.Method)
+	assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
+
+	body, _ := io.ReadAll(req.Body)
+	form, err := url.ParseQuery(string(body))
+	require.NoError(t, err)
+	assert.Equal(t, "CreateQueue", form.Get("Action"))
+	assert.Equal(t, "tasks", form.Get("QueueName"))
+}
+
+func TestConvert_SNS_CreateTopic(t *testing.T) {
+	event := CloudTrailEvent{
+		EventSource:       "sns.amazonaws.com",
+		EventName:         "CreateTopic",
+		AWSRegion:         "us-east-1",
+		RequestParameters: map[string]any{"Name": "alerts"},
+	}
+
+	req, err := ConvertToRequest(event, "http://localhost:4566")
+	require.NoError(t, err)
+
+	assert.Equal(t, "POST", req.Method)
+
+	body, _ := io.ReadAll(req.Body)
+	form, err := url.ParseQuery(string(body))
+	require.NoError(t, err)
+	assert.Equal(t, "CreateTopic", form.Get("Action"))
+	assert.Equal(t, "alerts", form.Get("Name"))
+}
+
+func TestConvert_IAM_CreateRole(t *testing.T) {
+	event := CloudTrailEvent{
+		EventSource: "iam.amazonaws.com",
+		EventName:   "CreateRole",
+		AWSRegion:   "us-east-1",
+		RequestParameters: map[string]any{
+			"roleName":                 "my-role",
+			"assumeRolePolicyDocument": `{"Version":"2012-10-17"}`,
+		},
+	}
+
+	req, err := ConvertToRequest(event, "http://localhost:4566")
+	require.NoError(t, err)
+
+	assert.Equal(t, "POST", req.Method)
+
+	body, _ := io.ReadAll(req.Body)
+	form, err := url.ParseQuery(string(body))
+	require.NoError(t, err)
+	assert.Equal(t, "CreateRole", form.Get("Action"))
+	assert.Equal(t, "my-role", form.Get("roleName"))
+}
+
+func TestConvert_UnknownAction(t *testing.T) {
+	event := CloudTrailEvent{
+		EventSource: "redshift.amazonaws.com",
+		EventName:   "CreateCluster",
+		AWSRegion:   "us-east-1",
+	}
+
+	_, err := ConvertToRequest(event, "http://localhost:4566")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported")
+}

--- a/pkg/cloudtrail/parser.go
+++ b/pkg/cloudtrail/parser.go
@@ -1,0 +1,104 @@
+// Package cloudtrail provides CloudTrail event parsing, conversion, and replay
+// for recreating AWS resource state from audit logs.
+package cloudtrail
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CloudTrailLog is the top-level wrapper for a CloudTrail JSON file.
+type CloudTrailLog struct {
+	Records []CloudTrailEvent `json:"Records"`
+}
+
+// CloudTrailEvent represents a single CloudTrail event record.
+type CloudTrailEvent struct {
+	EventVersion      string         `json:"eventVersion"`
+	EventSource       string         `json:"eventSource"`
+	EventName         string         `json:"eventName"`
+	AWSRegion         string         `json:"awsRegion"`
+	EventTime         string         `json:"eventTime"`
+	SourceIPAddress   string         `json:"sourceIPAddress"`
+	UserIdentity      map[string]any `json:"userIdentity"`
+	RequestParameters map[string]any `json:"requestParameters"`
+	ResponseElements  map[string]any `json:"responseElements"`
+	ErrorCode         string         `json:"errorCode"`
+	ErrorMessage      string         `json:"errorMessage"`
+	ReadOnly          bool           `json:"readOnly"`
+}
+
+// ServiceName extracts the service from eventSource (e.g., "s3.amazonaws.com" -> "s3").
+func (e *CloudTrailEvent) ServiceName() string {
+	s := e.EventSource
+	if idx := strings.Index(s, "."); idx > 0 {
+		return s[:idx]
+	}
+	return s
+}
+
+// ParsedTime returns the eventTime parsed as time.Time.
+func (e *CloudTrailEvent) ParsedTime() time.Time {
+	t, err := time.Parse(time.RFC3339, e.EventTime)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// ParseFile reads a CloudTrail JSON file and returns the events.
+func ParseFile(path string) ([]CloudTrailEvent, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseJSON(data)
+}
+
+// ParseJSON parses CloudTrail JSON data (a Records array) and returns the events.
+func ParseJSON(data []byte) ([]CloudTrailEvent, error) {
+	var log CloudTrailLog
+	if err := json.Unmarshal(data, &log); err != nil {
+		return nil, err
+	}
+	return log.Records, nil
+}
+
+// FilterWriteEvents returns only events that modify state (not read-only).
+func FilterWriteEvents(events []CloudTrailEvent) []CloudTrailEvent {
+	var out []CloudTrailEvent
+	for _, e := range events {
+		if !e.ReadOnly {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// FilterByServices returns only events matching the given service names.
+func FilterByServices(events []CloudTrailEvent, services []string) []CloudTrailEvent {
+	if len(services) == 0 {
+		return events
+	}
+	allowed := make(map[string]bool, len(services))
+	for _, s := range services {
+		allowed[strings.ToLower(s)] = true
+	}
+	var out []CloudTrailEvent
+	for _, e := range events {
+		if allowed[e.ServiceName()] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// SortByTime sorts events chronologically by eventTime.
+func SortByTime(events []CloudTrailEvent) {
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].EventTime < events[j].EventTime
+	})
+}

--- a/pkg/cloudtrail/parser_test.go
+++ b/pkg/cloudtrail/parser_test.go
@@ -1,0 +1,68 @@
+package cloudtrail
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_SingleEvent(t *testing.T) {
+	data := `{"Records":[{"eventSource":"s3.amazonaws.com","eventName":"CreateBucket","eventTime":"2026-04-01T10:00:00Z","awsRegion":"us-east-1","requestParameters":{"bucketName":"test"}}]}`
+	events, err := ParseJSON([]byte(data))
+	require.NoError(t, err)
+	assert.Len(t, events, 1)
+	assert.Equal(t, "s3", events[0].ServiceName())
+	assert.Equal(t, "CreateBucket", events[0].EventName)
+}
+
+func TestParse_MultipleEvents(t *testing.T) {
+	data := `{"Records":[
+		{"eventSource":"dynamodb.amazonaws.com","eventName":"CreateTable","eventTime":"2026-04-01T10:00:00Z","awsRegion":"us-east-1","requestParameters":{"tableName":"Users"}},
+		{"eventSource":"sqs.amazonaws.com","eventName":"CreateQueue","eventTime":"2026-04-01T10:01:00Z","awsRegion":"us-east-1","requestParameters":{"QueueName":"tasks"}}
+	]}`
+	events, err := ParseJSON([]byte(data))
+	require.NoError(t, err)
+	assert.Len(t, events, 2)
+	assert.Equal(t, "dynamodb", events[0].ServiceName())
+	assert.Equal(t, "sqs", events[1].ServiceName())
+}
+
+func TestParse_FilterWriteEvents(t *testing.T) {
+	events := []CloudTrailEvent{
+		{EventName: "CreateTable", ReadOnly: false},
+		{EventName: "DescribeTable", ReadOnly: true},
+		{EventName: "PutItem", ReadOnly: false},
+	}
+	writes := FilterWriteEvents(events)
+	assert.Len(t, writes, 2)
+	assert.Equal(t, "CreateTable", writes[0].EventName)
+	assert.Equal(t, "PutItem", writes[1].EventName)
+}
+
+func TestParse_SortByTime(t *testing.T) {
+	events := []CloudTrailEvent{
+		{EventName: "Third", EventTime: "2026-04-01T12:00:00Z"},
+		{EventName: "First", EventTime: "2026-04-01T10:00:00Z"},
+		{EventName: "Second", EventTime: "2026-04-01T11:00:00Z"},
+	}
+	SortByTime(events)
+	assert.Equal(t, "First", events[0].EventName)
+	assert.Equal(t, "Second", events[1].EventName)
+	assert.Equal(t, "Third", events[2].EventName)
+}
+
+func TestParse_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trail.json")
+	data := `{"Records":[{"eventSource":"sns.amazonaws.com","eventName":"CreateTopic","eventTime":"2026-04-01T10:00:00Z","awsRegion":"us-east-1","requestParameters":{"Name":"alerts"}}]}`
+	err := os.WriteFile(path, []byte(data), 0644)
+	require.NoError(t, err)
+
+	events, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.Len(t, events, 1)
+	assert.Equal(t, "sns", events[0].ServiceName())
+}

--- a/pkg/cloudtrail/replay.go
+++ b/pkg/cloudtrail/replay.go
@@ -1,0 +1,121 @@
+package cloudtrail
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ReplayConfig controls how events are replayed against a CloudMock endpoint.
+type ReplayConfig struct {
+	Endpoint    string   // CloudMock gateway URL
+	Speed       float64  // 0 = instant, 1.0 = realtime
+	FilterWrite bool     // If true, skip read-only events
+	Services    []string // If non-empty, only replay matching services
+}
+
+// ReplayResult summarizes the outcome of a replay run.
+type ReplayResult struct {
+	TotalEvents int           `json:"total_events"`
+	Replayed    int           `json:"replayed"`
+	Skipped     int           `json:"skipped"`
+	Succeeded   int           `json:"succeeded"`
+	Failed      int           `json:"failed"`
+	Errors      []ReplayError `json:"errors,omitempty"`
+	Duration    time.Duration `json:"duration"`
+}
+
+// ReplayError records a single failed replay attempt.
+type ReplayError struct {
+	EventName string `json:"event_name"`
+	Service   string `json:"service"`
+	Error     string `json:"error"`
+	Status    int    `json:"status"`
+}
+
+// Replay sends CloudTrail events to a CloudMock endpoint according to the
+// provided configuration and returns a summary of the results.
+func Replay(events []CloudTrailEvent, cfg ReplayConfig) (*ReplayResult, error) {
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("endpoint is required")
+	}
+
+	start := time.Now()
+	totalEvents := len(events)
+
+	// Apply filters.
+	filtered := make([]CloudTrailEvent, len(events))
+	copy(filtered, events)
+
+	if cfg.FilterWrite {
+		filtered = FilterWriteEvents(filtered)
+	}
+	if len(cfg.Services) > 0 {
+		filtered = FilterByServices(filtered, cfg.Services)
+	}
+
+	// Sort chronologically.
+	SortByTime(filtered)
+
+	skipped := totalEvents - len(filtered)
+
+	result := &ReplayResult{
+		TotalEvents: totalEvents,
+		Skipped:     skipped,
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	for i, event := range filtered {
+		// Respect speed: sleep based on time delta between consecutive events.
+		if cfg.Speed > 0 && i > 0 {
+			prev := filtered[i-1].ParsedTime()
+			curr := event.ParsedTime()
+			if !prev.IsZero() && !curr.IsZero() {
+				delta := curr.Sub(prev)
+				if delta > 0 {
+					sleepDuration := time.Duration(float64(delta) / cfg.Speed)
+					time.Sleep(sleepDuration)
+				}
+			}
+		}
+
+		req, err := ConvertToRequest(event, cfg.Endpoint)
+		if err != nil {
+			result.Skipped++
+			continue
+		}
+
+		resp, err := client.Do(req)
+		result.Replayed++
+		if err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, ReplayError{
+				EventName: event.EventName,
+				Service:   event.ServiceName(),
+				Error:     err.Error(),
+				Status:    0,
+			})
+			continue
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+			result.Succeeded++
+		} else {
+			result.Failed++
+			result.Errors = append(result.Errors, ReplayError{
+				EventName: event.EventName,
+				Service:   event.ServiceName(),
+				Error:     fmt.Sprintf("HTTP %d", resp.StatusCode),
+				Status:    resp.StatusCode,
+			})
+		}
+	}
+
+	result.Duration = time.Since(start)
+
+	return result, nil
+}

--- a/pkg/cloudtrail/replay_test.go
+++ b/pkg/cloudtrail/replay_test.go
@@ -1,0 +1,160 @@
+package cloudtrail
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplay_SendsRequests(t *testing.T) {
+	var mu sync.Mutex
+	var received []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		received = append(received, r.Header.Get("X-Amz-Target"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	events := []CloudTrailEvent{
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:00:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"tableName": "A"}},
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:01:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"tableName": "B"}},
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:02:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"tableName": "C"}},
+	}
+
+	result, err := Replay(events, ReplayConfig{Endpoint: srv.URL, Speed: 0})
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.Replayed)
+	assert.Equal(t, 3, result.Succeeded)
+
+	mu.Lock()
+	assert.Len(t, received, 3)
+	mu.Unlock()
+}
+
+func TestReplay_ChronologicalOrder(t *testing.T) {
+	var mu sync.Mutex
+	var order []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		target := r.Header.Get("X-Amz-Target")
+		mu.Lock()
+		order = append(order, target)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Events in reverse chronological order.
+	events := []CloudTrailEvent{
+		{EventSource: "dynamodb.amazonaws.com", EventName: "PutItem", EventTime: "2026-04-01T12:00:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{}},
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:00:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"tableName": "X"}},
+	}
+
+	result, err := Replay(events, ReplayConfig{Endpoint: srv.URL, Speed: 0})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Replayed)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, order, 2)
+	// CreateTable should come before PutItem because it has an earlier timestamp.
+	assert.Equal(t, "DynamoDB_20120810.CreateTable", order[0])
+	assert.Equal(t, "DynamoDB_20120810.PutItem", order[1])
+}
+
+func TestReplay_SkipsReadOnly(t *testing.T) {
+	var mu sync.Mutex
+	var count int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	events := []CloudTrailEvent{
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:00:00Z", AWSRegion: "us-east-1", ReadOnly: false, RequestParameters: map[string]any{"tableName": "T"}},
+		{EventSource: "dynamodb.amazonaws.com", EventName: "GetItem", EventTime: "2026-04-01T10:01:00Z", AWSRegion: "us-east-1", ReadOnly: true, RequestParameters: map[string]any{}},
+		{EventSource: "s3.amazonaws.com", EventName: "CreateBucket", EventTime: "2026-04-01T10:02:00Z", AWSRegion: "us-east-1", ReadOnly: false, RequestParameters: map[string]any{"bucketName": "b"}},
+	}
+
+	result, err := Replay(events, ReplayConfig{Endpoint: srv.URL, Speed: 0, FilterWrite: true})
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.TotalEvents)
+	assert.Equal(t, 2, result.Replayed)
+	assert.Equal(t, 1, result.Skipped)
+
+	mu.Lock()
+	assert.Equal(t, 2, count)
+	mu.Unlock()
+}
+
+func TestReplay_ServiceFilter(t *testing.T) {
+	var mu sync.Mutex
+	var count int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	events := []CloudTrailEvent{
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:00:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"tableName": "T"}},
+		{EventSource: "s3.amazonaws.com", EventName: "CreateBucket", EventTime: "2026-04-01T10:01:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"bucketName": "b"}},
+		{EventSource: "sqs.amazonaws.com", EventName: "CreateQueue", EventTime: "2026-04-01T10:02:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"QueueName": "q"}},
+	}
+
+	result, err := Replay(events, ReplayConfig{
+		Endpoint: srv.URL,
+		Speed:    0,
+		Services: []string{"s3"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.TotalEvents)
+	assert.Equal(t, 1, result.Replayed)
+	assert.Equal(t, 2, result.Skipped)
+
+	mu.Lock()
+	assert.Equal(t, 1, count)
+	mu.Unlock()
+}
+
+func TestReplay_ReportCounts(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	events := []CloudTrailEvent{
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:00:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"tableName": "A"}},
+		{EventSource: "dynamodb.amazonaws.com", EventName: "CreateTable", EventTime: "2026-04-01T10:01:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"tableName": "B"}},
+		{EventSource: "s3.amazonaws.com", EventName: "CreateBucket", EventTime: "2026-04-01T10:02:00Z", AWSRegion: "us-east-1", RequestParameters: map[string]any{"bucketName": "c"}},
+	}
+
+	result, err := Replay(events, ReplayConfig{Endpoint: srv.URL, Speed: 0})
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.TotalEvents)
+	assert.Equal(t, 3, result.Replayed)
+	assert.Equal(t, 2, result.Succeeded)
+	assert.Equal(t, 1, result.Failed)
+	assert.Len(t, result.Errors, 1)
+	assert.Equal(t, 500, result.Errors[0].Status)
+}

--- a/website/src/content/docs/docs/guides/cloudtrail-replay.md
+++ b/website/src/content/docs/docs/guides/cloudtrail-replay.md
@@ -1,0 +1,146 @@
+---
+title: CloudTrail Event Replay
+description: Recreate production AWS state in CloudMock by replaying CloudTrail audit logs
+---
+
+CloudTrail event replay lets you take real AWS audit logs and replay the write operations against a CloudMock instance. This recreates your production resource topology locally -- tables, queues, buckets, topics, and more -- without manual setup.
+
+## How it works
+
+1. **Export** CloudTrail events from your AWS account
+2. **Parse** the JSON log file to extract write operations
+3. **Convert** each event into the correct AWS wire-protocol request (JSON, Query, or REST)
+4. **Replay** the requests against CloudMock in chronological order
+
+CloudMock handles the protocol conversion automatically. A DynamoDB `CreateTable` event becomes a JSON-protocol POST with the correct `X-Amz-Target` header. An SQS `CreateQueue` becomes a Query-protocol POST with `Action=CreateQueue`. An S3 `CreateBucket` becomes a REST `PUT /bucket-name`.
+
+## Getting CloudTrail logs
+
+Export recent events using the AWS CLI:
+
+```bash
+aws cloudtrail lookup-events \
+  --start-time 2026-03-01T00:00:00Z \
+  --end-time 2026-04-01T00:00:00Z \
+  --output json > trail.json
+```
+
+Or download a CloudTrail log file from S3 if you have a trail configured:
+
+```bash
+aws s3 cp s3://my-trail-bucket/AWSLogs/123456789012/CloudTrail/us-east-1/2026/04/01/trail.json.gz .
+gunzip trail.json.gz
+```
+
+The file must contain a top-level `Records` array in the standard CloudTrail format.
+
+## Replaying locally
+
+Start CloudMock, then replay:
+
+```bash
+# Start CloudMock
+npx cloudmock
+
+# Replay CloudTrail events (instant mode)
+cloudmock cloudtrail replay --input trail.json --endpoint http://localhost:4566
+```
+
+Output:
+
+```
+Replaying 847 CloudTrail events against http://localhost:4566
+
+CloudTrail Replay Results
+  Total events:  847
+  Replayed:      312
+  Skipped:       535
+  Succeeded:     308
+  Failed:        4
+  Duration:      1.2s
+```
+
+Skipped events are read-only operations (DescribeTable, GetObject, etc.) that do not modify state.
+
+## Filtering by service
+
+Replay only specific services:
+
+```bash
+cloudmock cloudtrail replay \
+  --input trail.json \
+  --services dynamodb,s3,sqs
+```
+
+## Speed control
+
+By default, events replay as fast as possible (`--speed 0`). To replay at real-time speed:
+
+```bash
+cloudmock cloudtrail replay --input trail.json --speed 1.0
+```
+
+Use `--speed 2.0` for double speed, or `--speed 0.5` for half speed.
+
+## Saving results
+
+Write the replay result to a JSON file:
+
+```bash
+cloudmock cloudtrail replay --input trail.json --output result.json
+```
+
+## Admin API
+
+You can also replay via the admin API:
+
+```bash
+curl -X POST http://localhost:4599/api/cloudtrail/replay \
+  -H "Content-Type: application/json" \
+  -d @trail.json
+```
+
+The response is a JSON object with `total_events`, `replayed`, `skipped`, `succeeded`, `failed`, and `errors` fields.
+
+## CI workflow
+
+Use CloudTrail replay in CI to bootstrap a realistic CloudMock environment before running integration tests:
+
+```yaml
+# .github/workflows/test.yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: viridian-inc/cloudmock-action@v1
+
+      - name: Replay production state
+        run: cloudmock cloudtrail replay --input fixtures/trail.json --output replay-result.json
+
+      - name: Run integration tests
+        run: npm test
+        env:
+          AWS_ENDPOINT_URL: http://localhost:4566
+```
+
+## Supported services
+
+CloudTrail replay supports the following services and their most common write operations:
+
+| Service | Example events |
+|---------|---------------|
+| DynamoDB | CreateTable, PutItem, UpdateItem, DeleteTable |
+| S3 | CreateBucket, PutObject, DeleteBucket, DeleteObject |
+| SQS | CreateQueue, SendMessage, DeleteQueue |
+| SNS | CreateTopic, Subscribe, Publish |
+| IAM | CreateRole, CreateUser |
+| KMS | CreateKey |
+| Lambda | CreateFunction, Invoke |
+| CloudWatch Logs | CreateLogGroup |
+| Kinesis | CreateStream |
+| EC2 | RunInstances |
+| CloudFormation | CreateStack |
+| STS | GetCallerIdentity |
+
+Unsupported events are silently skipped during replay.

--- a/website/src/content/docs/docs/reference/comparison.md
+++ b/website/src/content/docs/docs/reference/comparison.md
@@ -28,6 +28,7 @@ This page compares CloudMock with other popular AWS emulation and mocking tools.
 | **Persistence** | Snapshot, DuckDB, PostgreSQL | Pro tier (persistence) | In-memory only | In-memory only |
 | **State snapshots** | Built-in — export/import JSON, commit to git, `--state` flag on startup | Cloud Pods (Pro tier only) | No equivalent | No equivalent |
 | **Traffic recording & replay** | Built-in (proxy + Go SDK interceptor, validate subcommand) | No | No | No |
+| **CloudTrail event replay** | Built-in (recreate state from audit logs) | No | No | No |
 | **Contract testing** | Built-in (dual-mode proxy compares real AWS vs CloudMock live) | No | No | No |
 | **GitHub Action** | `viridian-inc/cloudmock-action@v1` — one-line CI setup | Yes (localstack-action) | No | No |
 | **Scaffolding CLI** | `create-cloudmock-app` — 9 templates (Node/Python/Go/Java/Rust) | No | No | No |
@@ -38,6 +39,7 @@ This page compares CloudMock with other popular AWS emulation and mocking tools.
 | Feature | CloudMock | LocalStack | Moto |
 |---|---|---|---|
 | Traffic recording & replay | Built-in (proxy + SDK interceptor) | No | No |
+| CloudTrail event replay | Built-in (recreate state from audit logs) | No | No |
 
 ## IaC tool support
 


### PR DESCRIPTION
Parse real CloudTrail JSON logs and replay write events against CloudMock. Supports DynamoDB, S3, SQS, SNS, IAM, KMS, Lambda. 16 tests, docs, CLI subcommand, admin API.