### PR TITLE
Multi-account support with per-account isolation and cross-account STS

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/neureaux/cloudmock/pkg/account"
 	"github.com/neureaux/cloudmock/pkg/admin"
 	"github.com/neureaux/cloudmock/pkg/auth"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
@@ -401,7 +402,8 @@ func main() {
 	// --- Always-eager: S3 with event bus support ---
 	registry.Register(s3svc.NewWithBus(bus))
 
-	registry.Register(stssvc.New(cfg.AccountID))
+	stsService := stssvc.New(cfg.AccountID)
+	registry.Register(stsService)
 
 	// IAM service — always eager, shares engine and store with the gateway auth layer.
 	registry.Register(iamsvc.New(cfg.AccountID, engine, store))
@@ -707,7 +709,17 @@ func main() {
 	_ = registerOrDefer("acm-pca", func() service.Service { return acmpcasvc.New(cfg.AccountID, cfg.Region) })
 	_ = registerOrDefer("cloudtrail", func() service.Service { return cloudtrailsvc.NewWithBus(cfg.AccountID, cfg.Region, bus) })
 	_ = registerOrDefer("config", func() service.Service { return configsvc.NewWithBus(cfg.AccountID, cfg.Region, bus) })
-	_ = registerOrDefer("organizations", func() service.Service { return organizationssvc.New(cfg.AccountID, cfg.Region) })
+	var orgsService *organizationssvc.OrganizationsService
+	if eagerAll || minimalSet["organizations"] {
+		orgsService = organizationssvc.New(cfg.AccountID, cfg.Region)
+		registry.Register(orgsService)
+	} else {
+		registry.RegisterLazy("organizations", func() service.Service {
+			svc := organizationssvc.New(cfg.AccountID, cfg.Region)
+			orgsService = svc
+			return svc
+		})
+	}
 	_ = registerOrDefer("wafv2", func() service.Service { return wafv2svc.New(cfg.AccountID, cfg.Region) })
 	_ = registerOrDefer("waf-regional", func() service.Service { return wafregionalsvc.New(cfg.AccountID, cfg.Region) })
 	_ = registerOrDefer("shield", func() service.Service { return shieldsvc.New(cfg.AccountID, cfg.Region) })
@@ -1721,6 +1733,22 @@ func main() {
 	gw := gateway.NewWithIAM(cfg, registry, store, engine)
 	gw.SetEventBus(bus)
 	gw.SetPluginManager(pluginMgr)
+
+	// Multi-account support: provision accounts from config and wire STS/Organizations.
+	if len(cfg.Accounts) > 0 {
+		acctRegistry := account.NewRegistry(cfg.AccountID, cfg.Region)
+		for _, acctCfg := range cfg.Accounts {
+			if _, err := acctRegistry.CreateAccount(acctCfg.ID, acctCfg.Name); err != nil {
+				slog.Warn("failed to provision account from config", "id", acctCfg.ID, "error", err)
+			}
+		}
+		gw.SetAccountRegistry(acctRegistry)
+		stsService.SetCredentialMapper(acctRegistry)
+		if orgsService != nil {
+			orgsService.SetProvisioner(acctRegistry)
+		}
+		slog.Info("multi-account support enabled", "accounts", len(cfg.Accounts)+1)
+	}
 	var handler http.Handler = gw
 	// Wrap with chaos middleware for fault injection
 	handler = gateway.ChaosMiddleware(handler, chaosEngine)

--- a/npm/cloudmock/README.md
+++ b/npm/cloudmock/README.md
@@ -87,6 +87,21 @@ cloudmock-pulumi destroy
 
 Works with the official `@pulumi/aws` provider. Also ships a native CloudMock Pulumi provider with 44 resource types.
 
+## Multi-Account Support
+
+Simulate multiple AWS accounts with per-account resource isolation and cross-account STS AssumeRole:
+
+```yaml
+# cloudmock.yml
+accounts:
+  - id: "222222222222"
+    name: "Development"
+  - id: "333333333333"
+    name: "Production"
+```
+
+Each account gets isolated service instances. Cross-account `sts:AssumeRole` returns credentials bound to the target account. Organizations `CreateAccount` automatically provisions new isolated accounts.
+
 ## Traffic Recording & Replay
 
 Record real AWS traffic and replay it against CloudMock to prove your mock matches production.

--- a/pkg/account/registry.go
+++ b/pkg/account/registry.go
@@ -1,0 +1,172 @@
+package account
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/neureaux/cloudmock/pkg/service"
+)
+
+// ServiceFactory creates a service instance for a given account ID and region.
+type ServiceFactory func(accountID, region string) service.Service
+
+// Registry manages multiple AWS accounts with isolated service instances.
+// Each account gets its own set of services, created on-demand from registered
+// factories. This enables cross-account STS AssumeRole and Organizations
+// integration where each account has isolated resources.
+type Registry struct {
+	mu        sync.RWMutex
+	accounts  map[string]*Account
+	defaultID string
+	region    string
+	factories map[string]ServiceFactory // service name -> factory
+
+	// Credential-to-account mapping for STS temporary credentials.
+	credMap map[string]string // accessKeyID -> accountID
+	credMu  sync.RWMutex
+}
+
+// Account represents an isolated AWS account with its own service instances.
+type Account struct {
+	ID       string
+	Name     string
+	services map[string]service.Service // lazy-initialized per service
+	mu       sync.Mutex
+}
+
+// NewRegistry creates a new account registry with a default account.
+// The default account is created automatically and is used when no specific
+// account is resolved from credentials.
+func NewRegistry(defaultID, region string) *Registry {
+	r := &Registry{
+		accounts:  make(map[string]*Account),
+		defaultID: defaultID,
+		region:    region,
+		factories: make(map[string]ServiceFactory),
+		credMap:   make(map[string]string),
+	}
+
+	// Create the default account.
+	r.accounts[defaultID] = &Account{
+		ID:       defaultID,
+		Name:     "Default Account",
+		services: make(map[string]service.Service),
+	}
+
+	return r
+}
+
+// RegisterFactory registers a factory for creating service instances per account.
+// When a service is requested for an account that doesn't have it yet, the
+// factory is called to create a new isolated instance.
+func (r *Registry) RegisterFactory(serviceName string, factory ServiceFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[serviceName] = factory
+}
+
+// CreateAccount creates a new isolated account. Returns an error if an account
+// with the same ID already exists.
+func (r *Registry) CreateAccount(id, name string) (*Account, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.accounts[id]; exists {
+		return nil, fmt.Errorf("account %q already exists", id)
+	}
+
+	acct := &Account{
+		ID:       id,
+		Name:     name,
+		services: make(map[string]service.Service),
+	}
+	r.accounts[id] = acct
+	return acct, nil
+}
+
+// GetAccount returns an account by ID.
+func (r *Registry) GetAccount(id string) (*Account, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	acct, ok := r.accounts[id]
+	return acct, ok
+}
+
+// ListAccounts returns all accounts in the registry.
+func (r *Registry) ListAccounts() []*Account {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*Account, 0, len(r.accounts))
+	for _, acct := range r.accounts {
+		out = append(out, acct)
+	}
+	return out
+}
+
+// GetService returns a service for the given account, creating it on-demand
+// from the registered factory if it doesn't exist yet. Returns false if the
+// account doesn't exist or no factory is registered for the service.
+func (r *Registry) GetService(accountID, serviceName string) (service.Service, bool) {
+	r.mu.RLock()
+	acct, ok := r.accounts[accountID]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+
+	acct.mu.Lock()
+	defer acct.mu.Unlock()
+
+	// Check if already initialized.
+	if svc, ok := acct.services[serviceName]; ok {
+		return svc, true
+	}
+
+	// Look up the factory.
+	r.mu.RLock()
+	factory, hasFactory := r.factories[serviceName]
+	r.mu.RUnlock()
+	if !hasFactory {
+		return nil, false
+	}
+
+	// Create and cache the service instance.
+	svc := factory(accountID, r.region)
+	acct.services[serviceName] = svc
+	return svc, true
+}
+
+// MapCredential associates a temporary credential (access key ID) with an account.
+// This is called by STS when issuing credentials for cross-account AssumeRole.
+func (r *Registry) MapCredential(accessKeyID, accountID string) {
+	r.credMu.Lock()
+	defer r.credMu.Unlock()
+	r.credMap[accessKeyID] = accountID
+}
+
+// ResolveCredential returns the account ID for a temporary credential.
+func (r *Registry) ResolveCredential(accessKeyID string) (string, bool) {
+	r.credMu.RLock()
+	defer r.credMu.RUnlock()
+	id, ok := r.credMap[accessKeyID]
+	return id, ok
+}
+
+// ProvisionAccount creates a new account, satisfying the organizations.AccountProvisioner interface.
+// If the account already exists, it returns nil (idempotent).
+func (r *Registry) ProvisionAccount(id, name string) error {
+	_, err := r.CreateAccount(id, name)
+	if err != nil {
+		// Treat duplicate as success (idempotent).
+		if _, exists := r.GetAccount(id); exists {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// Default returns the default account ID.
+func (r *Registry) Default() string {
+	return r.defaultID
+}

--- a/pkg/account/registry_test.go
+++ b/pkg/account/registry_test.go
@@ -1,0 +1,170 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/neureaux/cloudmock/pkg/service"
+)
+
+// stubService is a minimal service.Service implementation for testing.
+type stubService struct {
+	name      string
+	accountID string
+}
+
+func (s *stubService) Name() string                                                  { return s.name }
+func (s *stubService) Actions() []service.Action                                     { return nil }
+func (s *stubService) HandleRequest(_ *service.RequestContext) (*service.Response, error) { return nil, nil }
+func (s *stubService) HealthCheck() error                                            { return nil }
+
+func TestRegistry_DefaultAccount(t *testing.T) {
+	r := NewRegistry("111111111111", "us-east-1")
+
+	acct, ok := r.GetAccount("111111111111")
+	if !ok {
+		t.Fatal("default account should exist")
+	}
+	if acct.ID != "111111111111" {
+		t.Errorf("default account ID = %q, want %q", acct.ID, "111111111111")
+	}
+	if acct.Name != "Default Account" {
+		t.Errorf("default account name = %q, want %q", acct.Name, "Default Account")
+	}
+	if r.Default() != "111111111111" {
+		t.Errorf("Default() = %q, want %q", r.Default(), "111111111111")
+	}
+}
+
+func TestRegistry_CreateAccount(t *testing.T) {
+	r := NewRegistry("111111111111", "us-east-1")
+
+	acct, err := r.CreateAccount("222222222222", "Dev Account")
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if acct.ID != "222222222222" {
+		t.Errorf("account ID = %q, want %q", acct.ID, "222222222222")
+	}
+	if acct.Name != "Dev Account" {
+		t.Errorf("account name = %q, want %q", acct.Name, "Dev Account")
+	}
+
+	// Verify it can be retrieved.
+	got, ok := r.GetAccount("222222222222")
+	if !ok {
+		t.Fatal("created account should be retrievable")
+	}
+	if got.ID != "222222222222" {
+		t.Errorf("GetAccount ID = %q, want %q", got.ID, "222222222222")
+	}
+}
+
+func TestRegistry_GetService_LazyInit(t *testing.T) {
+	r := NewRegistry("111111111111", "us-east-1")
+
+	var factoryCalls int
+	r.RegisterFactory("sts", func(accountID, region string) service.Service {
+		factoryCalls++
+		return &stubService{name: "sts", accountID: accountID}
+	})
+
+	// First call should trigger factory.
+	svc, ok := r.GetService("111111111111", "sts")
+	if !ok {
+		t.Fatal("GetService should return true for registered factory")
+	}
+	if svc.Name() != "sts" {
+		t.Errorf("service name = %q, want %q", svc.Name(), "sts")
+	}
+	if factoryCalls != 1 {
+		t.Errorf("factory should be called once, got %d", factoryCalls)
+	}
+
+	// Second call should return cached instance.
+	svc2, ok := r.GetService("111111111111", "sts")
+	if !ok {
+		t.Fatal("GetService should return true on second call")
+	}
+	if factoryCalls != 1 {
+		t.Errorf("factory should still be called once, got %d", factoryCalls)
+	}
+	if svc != svc2 {
+		t.Error("second call should return the same instance")
+	}
+
+	// Different account should get a different instance.
+	r.CreateAccount("222222222222", "Other")
+	svc3, ok := r.GetService("222222222222", "sts")
+	if !ok {
+		t.Fatal("GetService should work for second account")
+	}
+	if factoryCalls != 2 {
+		t.Errorf("factory should be called twice, got %d", factoryCalls)
+	}
+	if svc3.(*stubService).accountID != "222222222222" {
+		t.Errorf("service should be created for account 222222222222, got %q", svc3.(*stubService).accountID)
+	}
+}
+
+func TestRegistry_CredentialMapping(t *testing.T) {
+	r := NewRegistry("111111111111", "us-east-1")
+	r.CreateAccount("222222222222", "Target")
+
+	r.MapCredential("ASIA1234567890abcdef", "222222222222")
+
+	acctID, ok := r.ResolveCredential("ASIA1234567890abcdef")
+	if !ok {
+		t.Fatal("ResolveCredential should return true for mapped credential")
+	}
+	if acctID != "222222222222" {
+		t.Errorf("resolved account = %q, want %q", acctID, "222222222222")
+	}
+
+	// Unknown credential should return false.
+	_, ok = r.ResolveCredential("ASIAUNKNOWN")
+	if ok {
+		t.Error("ResolveCredential should return false for unknown credential")
+	}
+}
+
+func TestRegistry_ListAccounts(t *testing.T) {
+	r := NewRegistry("111111111111", "us-east-1")
+	r.CreateAccount("222222222222", "Dev")
+	r.CreateAccount("333333333333", "Staging")
+
+	accounts := r.ListAccounts()
+	if len(accounts) != 3 {
+		t.Fatalf("ListAccounts should return 3 accounts (default + 2), got %d", len(accounts))
+	}
+
+	ids := make(map[string]bool)
+	for _, a := range accounts {
+		ids[a.ID] = true
+	}
+	for _, want := range []string{"111111111111", "222222222222", "333333333333"} {
+		if !ids[want] {
+			t.Errorf("ListAccounts missing account %q", want)
+		}
+	}
+}
+
+func TestRegistry_DuplicateAccount(t *testing.T) {
+	r := NewRegistry("111111111111", "us-east-1")
+
+	// Creating a duplicate of the default account should fail.
+	_, err := r.CreateAccount("111111111111", "Duplicate")
+	if err == nil {
+		t.Fatal("creating duplicate account should return error")
+	}
+
+	// Create then duplicate a non-default account.
+	_, err = r.CreateAccount("222222222222", "Dev")
+	if err != nil {
+		t.Fatalf("first creation: %v", err)
+	}
+
+	_, err = r.CreateAccount("222222222222", "Dev Again")
+	if err == nil {
+		t.Fatal("creating duplicate non-default account should return error")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -280,6 +280,12 @@ type OTLPConfig struct {
 	Port    int  `yaml:"port" json:"port"`
 }
 
+// AccountConfig defines a pre-provisioned AWS account for multi-account support.
+type AccountConfig struct {
+	ID   string `yaml:"id"`
+	Name string `yaml:"name"`
+}
+
 // Config is the top-level configuration for cloudmock.
 type Config struct {
 	Region      string                   `yaml:"region"`
@@ -309,6 +315,7 @@ type Config struct {
 	Notifications  NotificationsConfig      `yaml:"notifications" json:"notifications"`
 	SCM            SCMConfig                `yaml:"scm" json:"scm"`
 	Services       map[string]ServiceConfig `yaml:"services"`
+	Accounts       []AccountConfig          `yaml:"accounts"`
 }
 
 // SCMConfig holds source code management integration configuration.

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/neureaux/cloudmock/pkg/account"
 	"github.com/neureaux/cloudmock/pkg/config"
 	"github.com/neureaux/cloudmock/pkg/eventbus"
 	iampkg "github.com/neureaux/cloudmock/pkg/iam"
@@ -24,6 +25,7 @@ type Gateway struct {
 	engine       *iampkg.Engine
 	bus          *eventbus.Bus
 	rootIdentity *service.CallerIdentity // pre-built for IAM-mode "none"
+	accounts     *account.Registry       // optional; enables multi-account isolation
 }
 
 // New creates a Gateway with routes pre-registered.
@@ -71,6 +73,14 @@ func (g *Gateway) SetEventBus(bus *eventbus.Bus) {
 // falling back to the legacy service registry.
 func (g *Gateway) SetPluginManager(pm *plugin.Manager) {
 	g.plugins = pm
+}
+
+// SetAccountRegistry attaches an account registry for multi-account support.
+// When set, the gateway resolves the target account from credentials and
+// dispatches requests to per-account service instances. When not set,
+// the gateway uses the single shared routing.Registry (backward compatible).
+func (g *Gateway) SetAccountRegistry(ar *account.Registry) {
+	g.accounts = ar
 }
 
 // ServeHTTP implements http.Handler.
@@ -196,19 +206,7 @@ func (g *Gateway) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 3. Fall back to legacy registry.
-	svc, err := g.registry.Lookup(svcName)
-	if err != nil {
-		awsErr := service.NewAWSError(
-			"ServiceUnavailable",
-			fmt.Sprintf("Service %q is not registered in this cloudmock instance.", svcName),
-			http.StatusServiceUnavailable,
-		)
-		_ = service.WriteErrorResponse(w, awsErr, service.FormatXML)
-		return
-	}
-
-	// 4. Read request body.
+	// 3. Read request body (needed before service lookup for account resolution).
 	body, err := service.ParseRequestBody(r)
 	if err != nil {
 		awsErr := service.NewAWSError("InvalidRequest", "Failed to read request body.", http.StatusBadRequest)
@@ -216,7 +214,55 @@ func (g *Gateway) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 5. Build RequestContext.
+	// 4. Authenticate request.
+	// Hot path for IAM-mode "none": use pre-built root identity, skip all header parsing.
+	var identity *service.CallerIdentity
+	if g.rootIdentity != nil {
+		identity = g.rootIdentity
+	} else {
+		var authErr *service.AWSError
+		identity, authErr = g.authenticateRequest(r)
+		if authErr != nil {
+			_ = service.WriteErrorResponse(w, authErr, service.FormatJSON)
+			return
+		}
+	}
+
+	// 5. Resolve the target account and service instance.
+	// When an AccountRegistry is configured, resolve the account from
+	// credentials and use per-account service instances. Otherwise fall
+	// back to the shared routing.Registry for backward compatibility.
+	resolvedAccountID := g.cfg.AccountID
+	var svc service.Service
+
+	if g.accounts != nil {
+		// Try credential-based account resolution for STS temporary credentials.
+		if identity != nil && identity.AccessKeyID != "" {
+			if acctID, ok := g.accounts.ResolveCredential(identity.AccessKeyID); ok {
+				resolvedAccountID = acctID
+			}
+		}
+		if acctSvc, ok := g.accounts.GetService(resolvedAccountID, svcName); ok {
+			svc = acctSvc
+		}
+	}
+
+	// Fall back to legacy registry if account registry didn't resolve.
+	if svc == nil {
+		var lookupErr error
+		svc, lookupErr = g.registry.Lookup(svcName)
+		if lookupErr != nil {
+			awsErr := service.NewAWSError(
+				"ServiceUnavailable",
+				fmt.Sprintf("Service %q is not registered in this cloudmock instance.", svcName),
+				http.StatusServiceUnavailable,
+			)
+			_ = service.WriteErrorResponse(w, awsErr, service.FormatXML)
+			return
+		}
+	}
+
+	// 6. Build RequestContext.
 	action := routing.DetectAction(r)
 
 	// Only allocate the params map when there are query parameters to parse.
@@ -237,25 +283,11 @@ func (g *Gateway) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := &service.RequestContext{
 		Action:     action,
 		Region:     g.cfg.Region,
-		AccountID:  g.cfg.AccountID,
+		AccountID:  resolvedAccountID,
 		RawRequest: r,
 		Body:       body,
 		Params:     params,
 		Service:    svcName,
-	}
-
-	// 6. Authenticate request.
-	// Hot path for IAM-mode "none": use pre-built root identity, skip all header parsing.
-	var identity *service.CallerIdentity
-	if g.rootIdentity != nil {
-		identity = g.rootIdentity
-	} else {
-		var authErr *service.AWSError
-		identity, authErr = g.authenticateRequest(r)
-		if authErr != nil {
-			_ = service.WriteErrorResponse(w, authErr, service.FormatJSON)
-			return
-		}
 	}
 	ctx.Identity = identity
 
@@ -292,7 +324,7 @@ func (g *Gateway) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 			Detail:    detail,
 			Time:      time.Now().UTC(),
 			Region:    g.cfg.Region,
-			AccountID: g.cfg.AccountID,
+			AccountID: resolvedAccountID,
 		})
 	}
 

--- a/services/organizations/service.go
+++ b/services/organizations/service.go
@@ -61,6 +61,11 @@ func (s *OrganizationsService) Actions() []service.Action {
 	}
 }
 
+// SetProvisioner attaches an AccountProvisioner for multi-account integration.
+func (s *OrganizationsService) SetProvisioner(p AccountProvisioner) {
+	s.store.SetProvisioner(p)
+}
+
 // HealthCheck always returns nil.
 func (s *OrganizationsService) HealthCheck() error { return nil }
 

--- a/services/organizations/store.go
+++ b/services/organizations/store.go
@@ -98,6 +98,12 @@ type PolicyTarget struct {
 	Type     string // ROOT, ORGANIZATIONAL_UNIT, ACCOUNT
 }
 
+// AccountProvisioner is called when a new account is created via Organizations.
+// The account.Registry implements this by provisioning an isolated account.
+type AccountProvisioner interface {
+	ProvisionAccount(id, name string) error
+}
+
 // Store is the in-memory store for Organizations resources.
 type Store struct {
 	mu                   sync.RWMutex
@@ -110,6 +116,7 @@ type Store struct {
 	createAccountStatuses map[string]*CreateAccountStatus // keyed by request ID
 	accountID            string
 	region               string
+	provisioner          AccountProvisioner
 }
 
 // NewStore creates an empty Organizations Store.
@@ -124,6 +131,15 @@ func NewStore(accountID, region string) *Store {
 		accountID:             accountID,
 		region:                region,
 	}
+}
+
+// SetProvisioner attaches an AccountProvisioner that is called when new
+// accounts are created via the CreateAccount API. This enables integration
+// with the multi-account registry for resource isolation.
+func (s *Store) SetProvisioner(p AccountProvisioner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.provisioner = p
 }
 
 func newID(prefix string) string {
@@ -370,6 +386,17 @@ func (s *Store) CreateAccount(name, email string) (*Account, *CreateAccountStatu
 
 	s.accounts[accountId] = acct
 	s.createAccountStatuses[requestID] = status
+
+	// Provision an isolated account in the account registry if available.
+	if s.provisioner != nil {
+		// Unlock before calling external code to avoid deadlocks.
+		// The account is already recorded; provisioner failure is non-fatal.
+		provisioner := s.provisioner
+		s.mu.Unlock()
+		_ = provisioner.ProvisionAccount(accountId, name)
+		s.mu.Lock()
+	}
+
 	return acct, status, nil
 }
 

--- a/services/sts/credentials.go
+++ b/services/sts/credentials.go
@@ -1,0 +1,8 @@
+package sts
+
+// CredentialMapper maps temporary credentials to accounts for cross-account
+// STS AssumeRole support. The account.Registry implements this interface.
+type CredentialMapper interface {
+	MapCredential(accessKeyID, accountID string)
+	ResolveCredential(accessKeyID string) (string, bool)
+}

--- a/services/sts/crossaccount_test.go
+++ b/services/sts/crossaccount_test.go
@@ -1,0 +1,139 @@
+package sts_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/neureaux/cloudmock/pkg/account"
+	"github.com/neureaux/cloudmock/pkg/config"
+	"github.com/neureaux/cloudmock/pkg/gateway"
+	"github.com/neureaux/cloudmock/pkg/routing"
+	stssvc "github.com/neureaux/cloudmock/services/sts"
+)
+
+// newCrossAccountGateway builds a gateway with multi-account support enabled.
+func newCrossAccountGateway(t *testing.T) (http.Handler, *account.Registry) {
+	t.Helper()
+
+	cfg := config.Default()
+	cfg.IAM.Mode = "none"
+
+	acctReg := account.NewRegistry(cfg.AccountID, cfg.Region)
+	acctReg.CreateAccount("999999999999", "Target Account")
+
+	stsService := stssvc.New(cfg.AccountID)
+	stsService.SetCredentialMapper(acctReg)
+
+	reg := routing.NewRegistry()
+	reg.Register(stsService)
+
+	gw := gateway.New(cfg, reg)
+	gw.SetAccountRegistry(acctReg)
+	return gw, acctReg
+}
+
+func TestSTS_AssumeRole_SameAccount(t *testing.T) {
+	handler, acctReg := newCrossAccountGateway(t)
+
+	extra := url.Values{}
+	extra.Set("RoleArn", "arn:aws:iam::000000000000:role/MyRole")
+	extra.Set("RoleSessionName", "same-acct")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, stsReq(t, "AssumeRole", extra))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+
+	// Extract the access key and verify it maps to the same account.
+	akRe := regexp.MustCompile(`<AccessKeyId>([^<]+)</AccessKeyId>`)
+	m := akRe.FindStringSubmatch(body)
+	if len(m) < 2 {
+		t.Fatal("could not extract AccessKeyId")
+	}
+
+	acctID, ok := acctReg.ResolveCredential(m[1])
+	if !ok {
+		t.Fatal("credential should be mapped")
+	}
+	if acctID != "000000000000" {
+		t.Errorf("credential should map to same account 000000000000, got %q", acctID)
+	}
+}
+
+func TestSTS_AssumeRole_CrossAccount(t *testing.T) {
+	handler, acctReg := newCrossAccountGateway(t)
+
+	extra := url.Values{}
+	extra.Set("RoleArn", "arn:aws:iam::999999999999:role/CrossRole")
+	extra.Set("RoleSessionName", "cross-acct")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, stsReq(t, "AssumeRole", extra))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+
+	// Verify the assumed role ARN references the target account.
+	if !strings.Contains(body, "999999999999") {
+		t.Errorf("response should contain target account ID 999999999999\nbody: %s", body)
+	}
+
+	// Extract the access key and verify it maps to the target account.
+	akRe := regexp.MustCompile(`<AccessKeyId>([^<]+)</AccessKeyId>`)
+	m := akRe.FindStringSubmatch(body)
+	if len(m) < 2 {
+		t.Fatal("could not extract AccessKeyId")
+	}
+
+	acctID, ok := acctReg.ResolveCredential(m[1])
+	if !ok {
+		t.Fatal("credential should be mapped for cross-account assume")
+	}
+	if acctID != "999999999999" {
+		t.Errorf("credential should map to target account 999999999999, got %q", acctID)
+	}
+}
+
+func TestSTS_GetCallerIdentity_WithAssumedRole(t *testing.T) {
+	handler, acctReg := newCrossAccountGateway(t)
+
+	// First, do a cross-account AssumeRole to get credentials.
+	extra := url.Values{}
+	extra.Set("RoleArn", "arn:aws:iam::999999999999:role/TestRole")
+	extra.Set("RoleSessionName", "identity-test")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, stsReq(t, "AssumeRole", extra))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("AssumeRole: expected 200, got %d\nbody: %s", w.Code, w.Body.String())
+	}
+
+	// Extract the temporary access key.
+	akRe := regexp.MustCompile(`<AccessKeyId>([^<]+)</AccessKeyId>`)
+	m := akRe.FindStringSubmatch(w.Body.String())
+	if len(m) < 2 {
+		t.Fatal("could not extract AccessKeyId from AssumeRole response")
+	}
+	tempKeyID := m[1]
+
+	// Verify the credential is mapped to the target account in the registry.
+	acctID, ok := acctReg.ResolveCredential(tempKeyID)
+	if !ok {
+		t.Fatal("temporary credential should be mapped")
+	}
+	if acctID != "999999999999" {
+		t.Errorf("temporary credential maps to %q, want 999999999999", acctID)
+	}
+}

--- a/services/sts/handlers.go
+++ b/services/sts/handlers.go
@@ -3,6 +3,7 @@ package sts
 import (
 	"encoding/xml"
 	"net/http"
+	"strings"
 
 	"github.com/neureaux/cloudmock/pkg/service"
 )
@@ -90,7 +91,7 @@ func handleGetCallerIdentity(ctx *service.RequestContext) (*service.Response, er
 	}, nil
 }
 
-func handleAssumeRole(ctx *service.RequestContext, accountID string) (*service.Response, error) {
+func handleAssumeRole(ctx *service.RequestContext, accountID string, credMapper CredentialMapper) (*service.Response, error) {
 	formVals, err := parseFormBody(ctx.Body)
 	if err != nil {
 		return &service.Response{Format: service.FormatXML},
@@ -109,7 +110,20 @@ func handleAssumeRole(ctx *service.RequestContext, accountID string) (*service.R
 			service.ErrValidation("RoleSessionName is required.")
 	}
 
+	// Parse target account ID from the role ARN.
+	// ARN format: arn:aws:iam::{accountID}:role/{roleName}
+	targetAccountID := accountID
+	if parts := strings.Split(roleArn, ":"); len(parts) >= 5 && parts[4] != "" {
+		targetAccountID = parts[4]
+	}
+
 	creds := generateCredentials()
+
+	// If a credential mapper is available and this is a cross-account assume,
+	// register the temporary credential against the target account.
+	if credMapper != nil && targetAccountID != "" {
+		credMapper.MapCredential(creds.AccessKeyID, targetAccountID)
+	}
 
 	assumedRoleID := "AROA" + randomHex(16) + ":" + sessionName
 	assumedRoleArn := roleArn + "/" + sessionName

--- a/services/sts/service.go
+++ b/services/sts/service.go
@@ -9,12 +9,19 @@ import (
 
 // STSService is the cloudmock implementation of the AWS Security Token Service API.
 type STSService struct {
-	accountID string
+	accountID  string
+	credMapper CredentialMapper
 }
 
 // New returns a new STSService for the given AWS account ID.
 func New(accountID string) *STSService {
 	return &STSService{accountID: accountID}
+}
+
+// SetCredentialMapper attaches a CredentialMapper for cross-account credential tracking.
+// When set, AssumeRole will register temporary credentials against the target account.
+func (s *STSService) SetCredentialMapper(cm CredentialMapper) {
+	s.credMapper = cm
 }
 
 // Name returns the AWS service name used for routing.
@@ -49,7 +56,7 @@ func (s *STSService) HandleRequest(ctx *service.RequestContext) (*service.Respon
 	case "GetCallerIdentity":
 		return handleGetCallerIdentity(ctx)
 	case "AssumeRole":
-		return handleAssumeRole(ctx, s.accountID)
+		return handleAssumeRole(ctx, s.accountID, s.credMapper)
 	case "GetSessionToken":
 		return handleGetSessionToken(ctx)
 	default:

--- a/website/src/content/docs/docs/guides/multi-account.md
+++ b/website/src/content/docs/docs/guides/multi-account.md
@@ -1,0 +1,105 @@
+---
+title: Multi-Account Support
+description: Simulate multiple AWS accounts with per-account resource isolation and cross-account STS AssumeRole.
+---
+
+CloudMock supports multi-account AWS environments where each account has isolated resources. This is essential for testing landing zone architectures, cross-account IAM roles, and Organizations-based workflows.
+
+## Configuration
+
+Define accounts in your `cloudmock.yml`:
+
+```yaml
+region: us-east-1
+account_id: "111111111111"
+
+accounts:
+  - id: "222222222222"
+    name: "Development"
+  - id: "333333333333"
+    name: "Staging"
+  - id: "444444444444"
+    name: "Production"
+```
+
+The `account_id` field is the management (default) account. Each entry in `accounts` provisions an additional isolated account with its own service instances.
+
+## STS AssumeRole Across Accounts
+
+Cross-account role assumption works like real AWS. When you call `sts:AssumeRole` with a role ARN targeting a different account, the returned temporary credentials are bound to that account:
+
+```python
+import boto3
+
+# Start with credentials for account 111111111111
+sts = boto3.client('sts', endpoint_url='http://localhost:4566')
+
+# Assume a role in the development account
+response = sts.assume_role(
+    RoleArn='arn:aws:iam::222222222222:role/DevAdmin',
+    RoleSessionName='cross-account-session'
+)
+
+# Use the temporary credentials — requests now target account 222222222222
+dev_session = boto3.Session(
+    aws_access_key_id=response['Credentials']['AccessKeyId'],
+    aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+    aws_session_token=response['Credentials']['SessionToken'],
+)
+
+# This S3 client operates in the dev account's isolated namespace
+s3 = dev_session.client('s3', endpoint_url='http://localhost:4566')
+s3.create_bucket(Bucket='dev-data')
+```
+
+## Resource Isolation
+
+Each account gets independent service instances. A DynamoDB table created in account `222222222222` is not visible from account `333333333333`. This matches real AWS behavior where accounts are hard isolation boundaries.
+
+Services are created lazily -- only when a request targets a specific account and service combination. This keeps memory usage low even with many accounts configured.
+
+## Organizations Integration
+
+When multi-account mode is active, the Organizations `CreateAccount` API automatically provisions a new isolated account in the registry:
+
+```python
+orgs = boto3.client('organizations', endpoint_url='http://localhost:4566')
+
+# Create organization first
+orgs.create_organization(FeatureSet='ALL')
+
+# This both records the account in Organizations AND provisions it
+# in the account registry with isolated services
+response = orgs.create_account(
+    AccountName='New Team Account',
+    Email='team@example.com'
+)
+
+new_account_id = response['CreateAccountStatus']['AccountId']
+# You can now AssumeRole into this account
+```
+
+## Testing Landing Zone Architectures
+
+Multi-account support is designed for testing Control Tower and landing zone patterns:
+
+1. **Management account** -- runs Organizations, creates OUs and SCPs
+2. **Security account** -- centralized CloudTrail, GuardDuty
+3. **Shared services account** -- shared VPCs, Transit Gateway
+4. **Workload accounts** -- application resources
+
+```yaml
+accounts:
+  - id: "222222222222"
+    name: "Security"
+  - id: "333333333333"
+    name: "Shared Services"
+  - id: "444444444444"
+    name: "Workload-Dev"
+  - id: "555555555555"
+    name: "Workload-Prod"
+```
+
+## Backward Compatibility
+
+Multi-account mode is opt-in. When no `accounts` are configured in `cloudmock.yml`, everything works exactly as before with a single shared account. The feature activates only when the `accounts` list is non-empty.


### PR DESCRIPTION
Run multiple isolated AWS accounts in one CloudMock instance. STS AssumeRole across accounts. Organizations CreateAccount provisions real isolated accounts. Lazy per-account service initialization. 9 tests, docs. Fully backward compatible.