### PR TITLE
chore: genericize brand-name leaks (autotend) in gateway + topology + logging

### DIFF
--- a/cloudmock.yml
+++ b/cloudmock.yml
@@ -90,3 +90,9 @@ slo:
 #     runtimes:
 #       - nodejs20.x
 #       - python3.12
+
+# Project-specific identifier prefixes. Stripped from topology node labels and
+# used to recognize caller-service IDs in User-Agent / X-Cloudmock-Source.
+# service_prefixes:
+#   - mycorp-
+#   - mycorp_

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -391,6 +391,8 @@ func main() {
 
 	cfg.ApplyEnv()
 
+	gateway.SetServicePrefixes(cfg.ServicePrefixes)
+
 	// Test mode: strip all observability, disable dashboard/admin/OTLP for maximum throughput.
 	// Use CLOUDMOCK_TEST_MODE=true when CloudMock is a test dependency.
 	testMode := os.Getenv("CLOUDMOCK_TEST_MODE") == "true" || os.Getenv("CLOUDMOCK_TEST_MODE") == "1"

--- a/pkg/admin/topology.go
+++ b/pkg/admin/topology.go
@@ -471,8 +471,9 @@ func (a *API) buildDynamicTopology() TopologyResponseV2 {
 
 	// Clean labels: strip project prefixes and env suffixes for display
 	env := a.environment()
+	prefixes := a.servicePrefixes()
 	for i := range nodes {
-		nodes[i].Label = cleanNodeLabel(nodes[i].Label, env)
+		nodes[i].Label = cleanNodeLabel(nodes[i].Label, env, prefixes)
 	}
 
 	// Enrich edges with latency stats from request log
@@ -487,10 +488,10 @@ func (a *API) buildDynamicTopology() TopologyResponseV2 {
 	}
 }
 
-// cleanNodeLabel strips common IaC prefixes and environment suffixes from node labels.
-func cleanNodeLabel(label, env string) string {
+// cleanNodeLabel strips configured IaC prefixes and the environment suffix from node labels.
+func cleanNodeLabel(label, env string, prefixes []string) string {
 	cleaned := label
-	for _, prefix := range []string{"autotend-", "autotend_"} {
+	for _, prefix := range prefixes {
 		cleaned = strings.TrimPrefix(cleaned, prefix)
 	}
 	if env != "" {
@@ -923,6 +924,15 @@ func (a *API) environment() string {
 		return a.cfg.IaCEnv
 	}
 	return "dev"
+}
+
+// servicePrefixes returns the configured service-name prefixes (e.g. ["mycorp-"])
+// used to strip noise from topology labels and recognize caller IDs in logs.
+func (a *API) servicePrefixes() []string {
+	if a.cfg == nil {
+		return nil
+	}
+	return a.cfg.ServicePrefixes
 }
 
 // serviceHasActivity checks if a service has received any traffic in the request log.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -347,6 +347,10 @@ type Config struct {
 	SCM            SCMConfig                `yaml:"scm" json:"scm"`
 	Services       map[string]ServiceConfig `yaml:"services"`
 	Accounts       []AccountConfig          `yaml:"accounts"`
+	// ServicePrefixes are stripped from topology node labels and recognized as
+	// caller identifiers in request logs. Empty by default; set to e.g.
+	// ["mycorp-", "mycorp_"] to recognize your IaC naming convention.
+	ServicePrefixes []string `yaml:"service_prefixes" json:"service_prefixes"`
 }
 
 // SCMConfig holds source code management integration configuration.

--- a/pkg/gateway/logging.go
+++ b/pkg/gateway/logging.go
@@ -628,9 +628,32 @@ func extractTraceMetadata(r *http.Request) map[string]string {
 	return meta
 }
 
+// servicePrefixes are User-Agent / source-name prefixes that identify caller
+// services in request logs (e.g. ["mycorp-"]). Set once at startup via
+// SetServicePrefixes; empty by default.
+var (
+	servicePrefixesMu sync.RWMutex
+	servicePrefixes   []string
+)
+
+// SetServicePrefixes configures the prefixes used by extractCallerID to
+// recognize caller-service identifiers embedded in User-Agent or
+// X-Cloudmock-Source headers. Safe to call once during startup.
+func SetServicePrefixes(prefixes []string) {
+	servicePrefixesMu.Lock()
+	defer servicePrefixesMu.Unlock()
+	servicePrefixes = append([]string(nil), prefixes...)
+}
+
+func getServicePrefixes() []string {
+	servicePrefixesMu.RLock()
+	defer servicePrefixesMu.RUnlock()
+	return servicePrefixes
+}
+
 func extractCallerID(r *http.Request) string {
 	// Prefer explicit source header from SDK-instrumented Lambda functions
-	// e.g. X-Cloudmock-Source: autotend-order-handler
+	// e.g. X-Cloudmock-Source: mycorp-order-handler
 	if src := r.Header.Get("X-Cloudmock-Source"); src != "" {
 		return src
 	}
@@ -638,11 +661,14 @@ func extractCallerID(r *http.Request) string {
 	// Fall back to User-Agent which AWS SDKs set to "aws-sdk-nodejs/3.x" etc.
 	// Some custom SDK configs include the function name
 	if ua := r.Header.Get("User-Agent"); ua != "" {
-		// Check for Lambda function name pattern in User-Agent
-		// e.g. "aws-sdk-nodejs/3.x autotend-order-handler"
-		if strings.Contains(ua, "autotend-") {
+		// Check for caller-service prefixes in the User-Agent
+		// e.g. "aws-sdk-nodejs/3.x mycorp-order-handler"
+		for _, prefix := range getServicePrefixes() {
+			if !strings.Contains(ua, prefix) {
+				continue
+			}
 			for _, part := range strings.Fields(ua) {
-				if strings.HasPrefix(part, "autotend-") {
+				if strings.HasPrefix(part, prefix) {
 					return part
 				}
 			}

--- a/pkg/gateway/proxy.go
+++ b/pkg/gateway/proxy.go
@@ -72,18 +72,18 @@ func backend(port int) string {
 
 // BuildRoutes generates the routing table dynamically from domain names and port config.
 // Order matters — more specific paths must come first.
-func BuildRoutes(autotendDomain, cloudmockDomain string) []ProxyRoute {
-	return BuildRoutesWithPorts(autotendDomain, cloudmockDomain, DefaultServicePorts())
+func BuildRoutes(primaryDomain, cloudmockDomain string) []ProxyRoute {
+	return BuildRoutesWithPorts(primaryDomain, cloudmockDomain, DefaultServicePorts())
 }
 
 // BuildRoutesWithPorts generates routes using explicit port configuration.
-func BuildRoutesWithPorts(autotendDomain, cloudmockDomain string, p ServicePorts) []ProxyRoute {
-	at := "localhost." + autotendDomain
+func BuildRoutesWithPorts(primaryDomain, cloudmockDomain string, p ServicePorts) []ProxyRoute {
+	primary := "localhost." + primaryDomain
 	cm := "localhost." + cloudmockDomain
 
 	return []ProxyRoute{
 		// .localhost domains (RFC 6761, zero config)
-		{Host: "autotend-app.localhost", Path: "/", Backend: backend(p.App), PreserveHost: true},
+		{Host: "app.localhost", Path: "/", Backend: backend(p.App), PreserveHost: true},
 		{Host: "cloudmock.localhost", Path: "/_cloudmock/", Backend: backend(p.Gateway)},
 		{Host: "cloudmock.localhost", Path: "/api/", Backend: backend(p.Admin)},
 		{Host: "cloudmock.localhost", Path: "/", Backend: backend(p.Dashboard)},
@@ -93,14 +93,14 @@ func BuildRoutesWithPorts(autotendDomain, cloudmockDomain string, p ServicePorts
 		{Host: "admin.localhost", Path: "/", Backend: backend(p.Admin)},
 		{Host: "graphql.localhost", Path: "/", Backend: backend(p.GraphQL)},
 
-		// custom domain: autotend app services
-		{Host: "autotend-app." + at, Path: "/", Backend: backend(p.App), PreserveHost: true},
-		{Host: "bff." + at, Path: "", Backend: backend(p.BFF)},
-		{Host: "api." + at, Path: "", Backend: backend(p.Gateway)},
-		{Host: "auth." + at, Path: "", Backend: backend(p.Gateway)},
-		{Host: "admin." + at, Path: "", Backend: backend(p.Admin)},
-		{Host: "graphql." + at, Path: "", Backend: backend(p.GraphQL)},
-		{Host: at, Path: "/", Backend: backend(p.App), PreserveHost: true},
+		// custom domain: app services
+		{Host: "app." + primary, Path: "/", Backend: backend(p.App), PreserveHost: true},
+		{Host: "bff." + primary, Path: "", Backend: backend(p.BFF)},
+		{Host: "api." + primary, Path: "", Backend: backend(p.Gateway)},
+		{Host: "auth." + primary, Path: "", Backend: backend(p.Gateway)},
+		{Host: "admin." + primary, Path: "", Backend: backend(p.Admin)},
+		{Host: "graphql." + primary, Path: "", Backend: backend(p.GraphQL)},
+		{Host: primary, Path: "/", Backend: backend(p.App), PreserveHost: true},
 
 		// custom domain: cloudmock dashboard
 		{Host: cm, Path: "/_cloudmock/", Backend: backend(p.Gateway)},

--- a/pkg/gateway/proxy_test.go
+++ b/pkg/gateway/proxy_test.go
@@ -10,7 +10,7 @@ func TestBuildRoutes_LocalhostRoutesExist(t *testing.T) {
 
 	// Verify all expected .localhost hosts are present
 	expectedHosts := []string{
-		"autotend-app.localhost",
+		"app.localhost",
 		"cloudmock.localhost",
 		"bff.localhost",
 		"api.localhost",
@@ -36,22 +36,22 @@ func TestBuildRoutes_LocalhostRoutesExist(t *testing.T) {
 func TestBuildRoutes_CustomDomainRoutesUseDomains(t *testing.T) {
 	routes := BuildRoutes("example.com", "mock.dev")
 
-	// Check autotend custom domain routes
-	atDomain := "localhost.example.com"
+	// Check primary-domain routes are present
+	primaryDomain := "localhost.example.com"
 	cmDomain := "localhost.mock.dev"
 
-	foundAT := false
+	foundPrimary := false
 	foundCM := false
 	for _, r := range routes {
-		if r.Host == atDomain || strings.HasSuffix(r.Host, "."+atDomain) {
-			foundAT = true
+		if r.Host == primaryDomain || strings.HasSuffix(r.Host, "."+primaryDomain) {
+			foundPrimary = true
 		}
 		if r.Host == cmDomain {
 			foundCM = true
 		}
 	}
 
-	if !foundAT {
+	if !foundPrimary {
 		t.Error("expected custom domain routes for localhost.example.com, not found")
 	}
 	if !foundCM {


### PR DESCRIPTION
## Summary

- **`pkg/gateway/proxy.go`** — rename the `autotend-app` route to `app` (now matches the `bff/api/auth/admin/graphql` sibling pattern); rename param/local `autotendDomain`/`at` → `primaryDomain`/`primary`.
- **`pkg/config/config.go`** — add `Config.ServicePrefixes []string` (yaml `service_prefixes`), empty by default.
- **`pkg/admin/topology.go`** — `cleanNodeLabel` now takes the prefix slice from `cfg.ServicePrefixes` instead of hardcoding `["autotend-", "autotend_"]`.
- **`pkg/gateway/logging.go`** — `extractCallerID` reads prefixes from a package-level slice settable via `gateway.SetServicePrefixes()` (RWMutex-guarded). `cmd/gateway/main.go` wires it from `cfg.ServicePrefixes` at startup.
- **`cloudmock.yml`** — documents the new optional `service_prefixes` block.

Closes #35.

## Migration

Existing CloudMock deployments that relied on the old `autotend-app.*` host or the implicit `autotend-` topology/log behavior should set:
```yaml
service_prefixes:
  - autotend-
  - autotend_
```
…and update any bookmarks/URLs from `autotend-app.<domain>` to `app.<domain>`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/gateway/... ./pkg/admin/... ./pkg/config/...`
- [x] `go vet ./pkg/gateway/... ./pkg/admin/... ./pkg/config/... ./cmd/gateway/...`
- [x] Confirmed the only pre-existing test failure (`TestAPIKeyStore_CreateAndGetByPlaintext` — needs Docker via testcontainers) reproduces on `origin/main` baseline, so unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)