### PR TITLE
chore: split pkg/gateway and pkg/proxy (Phase 1: pkg/dns + pkg/awsendpoints)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/Viridian-Inc/cloudmock/pkg/dataplane/memory"
 	pgImpl "github.com/Viridian-Inc/cloudmock/pkg/dataplane/postgres"
 	promImpl "github.com/Viridian-Inc/cloudmock/pkg/dataplane/prometheus"
+	"github.com/Viridian-Inc/cloudmock/pkg/dns"
 	"github.com/Viridian-Inc/cloudmock/pkg/eventbus"
 	"github.com/Viridian-Inc/cloudmock/pkg/profiling"
 	"github.com/Viridian-Inc/cloudmock/pkg/gateway"
@@ -2096,8 +2097,8 @@ func main() {
 		})
 
 		// DNS servers resolve *.localhost.<domain> → 127.0.0.1
-		go gateway.StartDNSServer(15353, "localhost."+primaryDomain)
-		go gateway.StartDNSServer(15354, "localhost."+cloudmockDomain)
+		go dns.StartDNSServer(15353, "localhost."+primaryDomain)
+		go dns.StartDNSServer(15354, "localhost."+cloudmockDomain)
 	}
 
 	addr := fmt.Sprintf(":%d", cfg.Gateway.Port)

--- a/pkg/awsendpoints/awsendpoints.go
+++ b/pkg/awsendpoints/awsendpoints.go
@@ -1,0 +1,132 @@
+// Package awsendpoints resolves AWS service names to their real public
+// hostnames and extracts service/action identifiers from incoming AWS SDK
+// requests.
+//
+// The endpoint table is intentionally hand-curated rather than derived from
+// the AWS SDK's endpoint-resolver data: AWS hostnames are not strictly
+// uniform (SES → email.<region>, Cognito user pools → cognito-idp, IAM/Route53/
+// CloudFront are global), so a small allowlist gives fail-closed behavior for
+// services we have not deliberately added.
+package awsendpoints
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// endpoints maps AWS service names to endpoint format strings.
+// Use fmt.Sprintf(pattern, region) for regional services; global services
+// have no %s and are returned as-is.
+var (
+	endpointsMu sync.RWMutex
+	endpoints   = map[string]string{
+		"s3":             "s3.%s.amazonaws.com",
+		"dynamodb":       "dynamodb.%s.amazonaws.com",
+		"sqs":            "sqs.%s.amazonaws.com",
+		"sns":            "sns.%s.amazonaws.com",
+		"lambda":         "lambda.%s.amazonaws.com",
+		"iam":            "iam.amazonaws.com",
+		"sts":            "sts.%s.amazonaws.com",
+		"kms":            "kms.%s.amazonaws.com",
+		"kinesis":        "kinesis.%s.amazonaws.com",
+		"firehose":       "firehose.%s.amazonaws.com",
+		"logs":           "logs.%s.amazonaws.com",
+		"events":         "events.%s.amazonaws.com",
+		"cloudwatch":     "monitoring.%s.amazonaws.com",
+		"cloudformation": "cloudformation.%s.amazonaws.com",
+		"ec2":            "ec2.%s.amazonaws.com",
+		"ecs":            "ecs.%s.amazonaws.com",
+		"eks":            "eks.%s.amazonaws.com",
+		"rds":            "rds.%s.amazonaws.com",
+		"route53":        "route53.amazonaws.com",
+		"cloudfront":     "cloudfront.amazonaws.com",
+		"ses":            "email.%s.amazonaws.com",
+		"cognito-idp":    "cognito-idp.%s.amazonaws.com",
+		"apigateway":     "apigateway.%s.amazonaws.com",
+		"secretsmanager": "secretsmanager.%s.amazonaws.com",
+		"ssm":            "ssm.%s.amazonaws.com",
+		"stepfunctions":  "states.%s.amazonaws.com",
+		"codebuild":      "codebuild.%s.amazonaws.com",
+		"codepipeline":   "codepipeline.%s.amazonaws.com",
+		"configservice":  "config.%s.amazonaws.com",
+		"cloudtrail":     "cloudtrail.%s.amazonaws.com",
+	}
+)
+
+// Resolve returns the real AWS hostname for a service and region, or "" if
+// the service is not in the allowlist.
+func Resolve(service, region string) string {
+	endpointsMu.RLock()
+	pattern, ok := endpoints[service]
+	endpointsMu.RUnlock()
+	if !ok {
+		return ""
+	}
+	if !strings.Contains(pattern, "%s") {
+		return pattern // global service
+	}
+	return fmt.Sprintf(pattern, region)
+}
+
+// ServiceFromAuth extracts the AWS service from the SigV4 Authorization
+// header credential scope: Credential=AKID/date/region/SERVICE/aws4_request.
+// Returns "" if the header is missing or unparseable.
+func ServiceFromAuth(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+
+	const prefix = "Credential="
+	idx := strings.Index(auth, prefix)
+	if idx < 0 {
+		return ""
+	}
+	rest := auth[idx+len(prefix):]
+
+	end := strings.IndexAny(rest, ", ")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+
+	parts := strings.Split(rest, "/")
+	if len(parts) < 4 {
+		return ""
+	}
+	return strings.ToLower(parts[3])
+}
+
+// Action extracts the AWS action name from the request. JSON-RPC services
+// carry it in the X-Amz-Target header (e.g. "DynamoDB_20120810.GetItem"),
+// query-based services carry it in the Action query parameter.
+func Action(r *http.Request) string {
+	if target := r.Header.Get("X-Amz-Target"); target != "" {
+		if dot := strings.LastIndex(target, "."); dot >= 0 {
+			return target[dot+1:]
+		}
+	}
+	return r.URL.Query().Get("Action")
+}
+
+// Override swaps the endpoint pattern for a single service and returns a
+// cleanup function that restores the previous value (or removes the entry
+// if the service was not previously known). Intended for tests that point
+// the recorder/contract proxy at a httptest.Server.
+func Override(service, hostPattern string) func() {
+	endpointsMu.Lock()
+	prev, existed := endpoints[service]
+	endpoints[service] = hostPattern
+	endpointsMu.Unlock()
+
+	return func() {
+		endpointsMu.Lock()
+		defer endpointsMu.Unlock()
+		if existed {
+			endpoints[service] = prev
+		} else {
+			delete(endpoints, service)
+		}
+	}
+}

--- a/pkg/awsendpoints/awsendpoints_test.go
+++ b/pkg/awsendpoints/awsendpoints_test.go
@@ -1,0 +1,158 @@
+package awsendpoints
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		service string
+		region  string
+		want    string
+	}{
+		{"s3", "us-east-1", "s3.us-east-1.amazonaws.com"},
+		{"iam", "us-east-1", "iam.amazonaws.com"},
+		{"dynamodb", "eu-west-1", "dynamodb.eu-west-1.amazonaws.com"},
+		{"route53", "us-east-1", "route53.amazonaws.com"},
+		{"cloudfront", "any", "cloudfront.amazonaws.com"},
+		{"ses", "eu-west-1", "email.eu-west-1.amazonaws.com"},
+		{"cognito-idp", "us-east-1", "cognito-idp.us-east-1.amazonaws.com"},
+		{"stepfunctions", "us-east-1", "states.us-east-1.amazonaws.com"},
+		{"cloudwatch", "us-east-1", "monitoring.us-east-1.amazonaws.com"},
+		{"unknown-service", "us-east-1", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.service, func(t *testing.T) {
+			got := Resolve(tt.service, tt.region)
+			if got != tt.want {
+				t.Errorf("Resolve(%q, %q) = %q, want %q", tt.service, tt.region, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceFromAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		auth string
+		want string
+	}{
+		{
+			name: "s3 from auth header",
+			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc",
+			want: "s3",
+		},
+		{
+			name: "dynamodb from auth header",
+			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/dynamodb/aws4_request, SignedHeaders=host, Signature=abc",
+			want: "dynamodb",
+		},
+		{
+			name: "sts from auth header",
+			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abc",
+			want: "sts",
+		},
+		{
+			name: "uppercase service is normalized",
+			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/S3/aws4_request, SignedHeaders=host, Signature=abc",
+			want: "s3",
+		},
+		{
+			name: "empty auth",
+			auth: "",
+			want: "",
+		},
+		{
+			name: "non-sigv4 auth",
+			auth: "Basic Zm9vOmJhcg==",
+			want: "",
+		},
+		{
+			name: "truncated credential scope",
+			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1, SignedHeaders=host, Signature=abc",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			if tt.auth != "" {
+				req.Header.Set("Authorization", tt.auth)
+			}
+			got := ServiceFromAuth(req)
+			if got != tt.want {
+				t.Errorf("ServiceFromAuth() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		query  string
+		want   string
+	}{
+		{"x-amz-target json-rpc", "DynamoDB_20120810.GetItem", "", "GetItem"},
+		{"x-amz-target nested", "Logs_20140328.CreateLogGroup", "", "CreateLogGroup"},
+		{"query Action param", "", "Action=SendMessage", "SendMessage"},
+		{"target wins over query", "DynamoDB_20120810.PutItem", "Action=Other", "PutItem"},
+		{"neither present", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/"
+			if tt.query != "" {
+				url = "/?" + tt.query
+			}
+			req := httptest.NewRequest("POST", url, nil)
+			if tt.target != "" {
+				req.Header.Set("X-Amz-Target", tt.target)
+			}
+			got := Action(req)
+			if got != tt.want {
+				t.Errorf("Action() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOverride_RestoresKnownService(t *testing.T) {
+	const svc = "s3"
+	original := Resolve(svc, "us-east-1")
+	if original == "" {
+		t.Fatalf("expected %s to be a known service before the test", svc)
+	}
+
+	cleanup := Override(svc, "fake-host")
+	if got := Resolve(svc, "us-east-1"); got != "fake-host" {
+		t.Errorf("after Override, Resolve = %q, want %q", got, "fake-host")
+	}
+
+	cleanup()
+	if got := Resolve(svc, "us-east-1"); got != original {
+		t.Errorf("after cleanup, Resolve = %q, want %q", got, original)
+	}
+}
+
+func TestOverride_RemovesUnknownService(t *testing.T) {
+	const svc = "this-service-does-not-exist"
+	if Resolve(svc, "us-east-1") != "" {
+		t.Fatalf("precondition: %s should not be in the table", svc)
+	}
+
+	cleanup := Override(svc, "fake-host")
+	if got := Resolve(svc, "us-east-1"); got != "fake-host" {
+		t.Errorf("after Override, Resolve = %q, want %q", got, "fake-host")
+	}
+
+	cleanup()
+	if got := Resolve(svc, "us-east-1"); got != "" {
+		t.Errorf("after cleanup of an originally-unknown service, Resolve = %q, want \"\"", got)
+	}
+}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,4 +1,10 @@
-package gateway
+// Package dns provides a minimal UDP DNS server that resolves a configured
+// domain (and any subdomain of it) to 127.0.0.1.
+//
+// It is intentionally dependency-free: DNS packets are parsed and constructed
+// using only the standard library. The server does no recursion or
+// forwarding — names that do not match the configured domain receive NXDOMAIN.
+package dns
 
 import (
 	"encoding/binary"
@@ -11,12 +17,9 @@ import (
 // Any A-record query for domain or *.domain is answered with 127.0.0.1.
 // All other queries receive an NXDOMAIN response (no forwarding).
 //
-// This is intentionally dependency-free — it parses and constructs DNS
-// packets manually using only the standard library.
-//
 // Typical usage (non-privileged port):
 //
-//	go gateway.StartDNSServer(15353, "localhost.autotend.io")
+//	go dns.StartDNSServer(15353, "localhost.example.com")
 func StartDNSServer(port int, domain string) {
 	addr := &net.UDPAddr{Port: port, IP: net.ParseIP("127.0.0.1")}
 	conn, err := net.ListenUDP("udp", addr)

--- a/pkg/proxy/contract.go
+++ b/pkg/proxy/contract.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Viridian-Inc/cloudmock/pkg/awsendpoints"
 	"github.com/Viridian-Inc/cloudmock/pkg/traffic"
 )
 
@@ -98,8 +99,8 @@ func (cp *ContractProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body.Close()
 	}
 
-	svc := detectServiceFromAuth(r)
-	action := detectAction(r)
+	svc := awsendpoints.ServiceFromAuth(r)
+	action := awsendpoints.Action(r)
 
 	type proxyResult struct {
 		statusCode int

--- a/pkg/proxy/integration_test.go
+++ b/pkg/proxy/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Viridian-Inc/cloudmock/pkg/awsendpoints"
 	"github.com/Viridian-Inc/cloudmock/pkg/traffic"
 )
 
@@ -49,17 +50,9 @@ func TestIntegration_RecordMultipleServices(t *testing.T) {
 	fakeHost := strings.TrimPrefix(mock.URL, "http://")
 
 	// Override endpoints for all three services to point at our mock server.
-	origS3 := serviceEndpoints["s3"]
-	origDynamo := serviceEndpoints["dynamodb"]
-	origSQS := serviceEndpoints["sqs"]
-	serviceEndpoints["s3"] = fakeHost
-	serviceEndpoints["dynamodb"] = fakeHost
-	serviceEndpoints["sqs"] = fakeHost
-	defer func() {
-		serviceEndpoints["s3"] = origS3
-		serviceEndpoints["dynamodb"] = origDynamo
-		serviceEndpoints["sqs"] = origSQS
-	}()
+	defer awsendpoints.Override("s3", fakeHost)()
+	defer awsendpoints.Override("dynamodb", fakeHost)()
+	defer awsendpoints.Override("sqs", fakeHost)()
 
 	p := New("us-east-1")
 	p.httpClient = &http.Client{Transport: &http.Transport{}}
@@ -136,14 +129,8 @@ func TestIntegration_SaveAndLoadRecording(t *testing.T) {
 
 	fakeHost := strings.TrimPrefix(mock.URL, "http://")
 
-	origS3 := serviceEndpoints["s3"]
-	origDynamo := serviceEndpoints["dynamodb"]
-	serviceEndpoints["s3"] = fakeHost
-	serviceEndpoints["dynamodb"] = fakeHost
-	defer func() {
-		serviceEndpoints["s3"] = origS3
-		serviceEndpoints["dynamodb"] = origDynamo
-	}()
+	defer awsendpoints.Override("s3", fakeHost)()
+	defer awsendpoints.Override("dynamodb", fakeHost)()
 
 	p := New("us-east-1")
 	p.httpClient = &http.Client{Transport: &http.Transport{}}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -13,43 +13,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Viridian-Inc/cloudmock/pkg/awsendpoints"
 	"github.com/Viridian-Inc/cloudmock/pkg/traffic"
 )
-
-// serviceEndpoints maps AWS service names to their endpoint format strings.
-// Use fmt.Sprintf(pattern, region) for regional services.
-var serviceEndpoints = map[string]string{
-	"s3":                      "s3.%s.amazonaws.com",
-	"dynamodb":                "dynamodb.%s.amazonaws.com",
-	"sqs":                     "sqs.%s.amazonaws.com",
-	"sns":                     "sns.%s.amazonaws.com",
-	"lambda":                  "lambda.%s.amazonaws.com",
-	"iam":                     "iam.amazonaws.com",
-	"sts":                     "sts.%s.amazonaws.com",
-	"kms":                     "kms.%s.amazonaws.com",
-	"kinesis":                 "kinesis.%s.amazonaws.com",
-	"firehose":                "firehose.%s.amazonaws.com",
-	"logs":                    "logs.%s.amazonaws.com",
-	"events":                  "events.%s.amazonaws.com",
-	"cloudwatch":              "monitoring.%s.amazonaws.com",
-	"cloudformation":          "cloudformation.%s.amazonaws.com",
-	"ec2":                     "ec2.%s.amazonaws.com",
-	"ecs":                     "ecs.%s.amazonaws.com",
-	"eks":                     "eks.%s.amazonaws.com",
-	"rds":                     "rds.%s.amazonaws.com",
-	"route53":                 "route53.amazonaws.com",
-	"cloudfront":              "cloudfront.amazonaws.com",
-	"ses":                     "email.%s.amazonaws.com",
-	"cognito-idp":             "cognito-idp.%s.amazonaws.com",
-	"apigateway":              "apigateway.%s.amazonaws.com",
-	"secretsmanager":          "secretsmanager.%s.amazonaws.com",
-	"ssm":                     "ssm.%s.amazonaws.com",
-	"stepfunctions":           "states.%s.amazonaws.com",
-	"codebuild":               "codebuild.%s.amazonaws.com",
-	"codepipeline":            "codepipeline.%s.amazonaws.com",
-	"configservice":           "config.%s.amazonaws.com",
-	"cloudtrail":              "cloudtrail.%s.amazonaws.com",
-}
 
 // AWSProxy is a reverse proxy that forwards requests to real AWS endpoints
 // and captures the request/response pairs as CapturedEntry values.
@@ -79,7 +45,7 @@ func New(region string) *AWSProxy {
 func (p *AWSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
-	svc := detectServiceFromAuth(r)
+	svc := awsendpoints.ServiceFromAuth(r)
 	if svc == "" {
 		http.Error(w, "could not detect AWS service from request", http.StatusBadGateway)
 		return
@@ -100,7 +66,7 @@ func (p *AWSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		targetURL = strings.TrimRight(p.testEndpoint, "/") + r.URL.RequestURI()
 		host = ""
 	} else {
-		host = resolveEndpoint(svc, p.region)
+		host = awsendpoints.Resolve(svc, p.region)
 		if host == "" {
 			http.Error(w, fmt.Sprintf("unknown service: %s", svc), http.StatusBadGateway)
 			return
@@ -147,7 +113,7 @@ func (p *AWSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		headers[k] = r.Header.Get(k)
 	}
 
-	action := detectAction(r)
+	action := awsendpoints.Action(r)
 
 	p.mu.Lock()
 	p.entrySeq++
@@ -221,51 +187,3 @@ func (p *AWSProxy) Entries() []*traffic.CapturedEntry {
 	return out
 }
 
-// detectServiceFromAuth extracts the AWS service from the Authorization header
-// credential scope: Credential=AKID/date/region/SERVICE/aws4_request.
-func detectServiceFromAuth(r *http.Request) string {
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		return ""
-	}
-
-	const prefix = "Credential="
-	idx := strings.Index(auth, prefix)
-	if idx < 0 {
-		return ""
-	}
-	rest := auth[idx+len(prefix):]
-
-	end := strings.IndexAny(rest, ", ")
-	if end >= 0 {
-		rest = rest[:end]
-	}
-
-	parts := strings.Split(rest, "/")
-	if len(parts) < 4 {
-		return ""
-	}
-	return strings.ToLower(parts[3])
-}
-
-// detectAction extracts the AWS action from the request.
-func detectAction(r *http.Request) string {
-	if target := r.Header.Get("X-Amz-Target"); target != "" {
-		if dot := strings.LastIndex(target, "."); dot >= 0 {
-			return target[dot+1:]
-		}
-	}
-	return r.URL.Query().Get("Action")
-}
-
-// resolveEndpoint returns the real AWS hostname for a service and region.
-func resolveEndpoint(service, region string) string {
-	pattern, ok := serviceEndpoints[service]
-	if !ok {
-		return ""
-	}
-	if !strings.Contains(pattern, "%s") {
-		return pattern // global service
-	}
-	return fmt.Sprintf(pattern, region)
-}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -9,49 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Viridian-Inc/cloudmock/pkg/awsendpoints"
 )
-
-func TestProxy_DetectsService(t *testing.T) {
-	tests := []struct {
-		name string
-		auth string
-		want string
-	}{
-		{
-			name: "s3 from auth header",
-			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc",
-			want: "s3",
-		},
-		{
-			name: "dynamodb from auth header",
-			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/dynamodb/aws4_request, SignedHeaders=host, Signature=abc",
-			want: "dynamodb",
-		},
-		{
-			name: "sts from auth header",
-			auth: "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abc",
-			want: "sts",
-		},
-		{
-			name: "empty auth",
-			auth: "",
-			want: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/", nil)
-			if tt.auth != "" {
-				req.Header.Set("Authorization", tt.auth)
-			}
-			got := detectServiceFromAuth(req)
-			if got != tt.want {
-				t.Errorf("detectServiceFromAuth() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
 
 // setupFakeAWS creates a fake AWS test server and configures the proxy to use it
 // for the given service. It returns the proxy and a cleanup function.
@@ -60,17 +20,15 @@ func setupFakeAWS(t *testing.T, service string, handler http.HandlerFunc) (*AWSP
 	fakeAWS := httptest.NewServer(handler)
 
 	p := New("us-east-1")
-	// Point the proxy's HTTP client at the fake server and override the endpoint.
 	fakeHost := strings.TrimPrefix(fakeAWS.URL, "http://")
-	origEndpoint := serviceEndpoints[service]
-	serviceEndpoints[service] = fakeHost
+	restore := awsendpoints.Override(service, fakeHost)
 
 	// Use a custom transport that speaks plain HTTP to the fake server.
 	p.httpClient = &http.Client{Transport: &http.Transport{}}
 
 	cleanup := func() {
 		fakeAWS.Close()
-		serviceEndpoints[service] = origEndpoint
+		restore()
 	}
 	return p, cleanup
 }
@@ -168,28 +126,6 @@ func TestProxy_SaveToFile(t *testing.T) {
 	entry := entries[0].(map[string]any)
 	if entry["service"] != "s3" {
 		t.Errorf("expected service 's3' in JSON, got %v", entry["service"])
-	}
-}
-
-func TestResolveEndpoint(t *testing.T) {
-	tests := []struct {
-		service string
-		region  string
-		want    string
-	}{
-		{"s3", "us-east-1", "s3.us-east-1.amazonaws.com"},
-		{"iam", "us-east-1", "iam.amazonaws.com"},
-		{"dynamodb", "eu-west-1", "dynamodb.eu-west-1.amazonaws.com"},
-		{"unknown-service", "us-east-1", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.service, func(t *testing.T) {
-			got := resolveEndpoint(tt.service, tt.region)
-			if got != tt.want {
-				t.Errorf("resolveEndpoint(%q, %q) = %q, want %q", tt.service, tt.region, got, tt.want)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the package-split refactor flagged in #37: extract the two truly independent concerns out of `pkg/gateway/` and `pkg/proxy/`.

- **`pkg/dns`** — moved from `pkg/gateway/dns.go`. UDP DNS server, zero internal deps, one external caller (`cmd/gateway/main.go`).
- **`pkg/awsendpoints`** — extracted `serviceEndpoints` + `Resolve` (was `resolveEndpoint`) + `ServiceFromAuth` (was `detectServiceFromAuth`) + `Action` (was `detectAction`) from `pkg/proxy/proxy.go`. Both `AWSProxy` and `ContractProxy` now consume the shared resolver. Adds an `Override(svc, host) func()` test helper with safe handling of originally-unknown service names.

Closes #37.

## Out of scope (deferred)

- **Phase 2** — reverse-proxy extraction (`pkg/gateway/proxy.go` → `pkg/edge`/`pkg/revproxy`). Blocked on a shared-observability package design — `proxy.go`'s `logProxyRequest` is intertwined with `RequestLog`/`RequestStats`/`RequestBroadcaster`/`GenerateTraceID`, also used by the AWS gateway handler.
- **Phase 3** — AWS gateway handler extraction (`gateway.go` + `iam_middleware.go` + `testmode*.go` → `pkg/awsgateway`). 77 external importers (~50 are service tests using `gateway.RequestEntry`); needs a renaming strategy to avoid churning every test in the repo.
- Consolidating the three copies of `serviceFromAuth` parsing (`pkg/awsendpoints` after this PR, `pkg/sdk/interceptor.go`, `tools/cloudmock-agent/sdk/observer.go`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/dns/... ./pkg/awsendpoints/... ./pkg/proxy/... ./pkg/gateway/... ./pkg/admin/... ./pkg/dataplane/... ./cmd/cloudmock/... ./cmd/gateway/...` — all green except the same pre-existing `pkg/dataplane/postgres` testcontainers/Docker failure that landed in #36 (Docker not running on this machine; reproduces on `origin/main` baseline)
- [x] `go vet ./pkg/dns/... ./pkg/awsendpoints/... ./pkg/proxy/... ./pkg/gateway/... ./cmd/gateway/... ./cmd/cloudmock/...`
- [x] `pkg/awsendpoints` includes round-trip tests for `Override` against both originally-known (`s3`) and originally-unknown service names (cleanup must `delete` rather than restore `""`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)