### PR TITLE
chore(iac): genericize Pulumi microservice parser via configurable class list

### DIFF
--- a/cloudmock.yml
+++ b/cloudmock.yml
@@ -96,3 +96,9 @@ slo:
 # service_prefixes:
 #   - mycorp-
 #   - mycorp_
+
+# TypeScript class names whose `new <Class>(...)` invocations in your Pulumi
+# project denote a Lambda-backed microservice. Empty by default — set this if
+# you have a custom Pulumi component that wraps Lambda + API routes.
+# iac_microservice_classes:
+#   - MyCorpLambdaModuleResource

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -393,6 +393,7 @@ func main() {
 	cfg.ApplyEnv()
 
 	gateway.SetServicePrefixes(cfg.ServicePrefixes)
+	iac.SetMicroserviceClasses(cfg.IaCMicroserviceClasses)
 
 	// Test mode: strip all observability, disable dashboard/admin/OTLP for maximum throughput.
 	// Use CLOUDMOCK_TEST_MODE=true when CloudMock is a test dependency.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -351,6 +351,11 @@ type Config struct {
 	// caller identifiers in request logs. Empty by default; set to e.g.
 	// ["mycorp-", "mycorp_"] to recognize your IaC naming convention.
 	ServicePrefixes []string `yaml:"service_prefixes" json:"service_prefixes"`
+	// IaCMicroserviceClasses are TypeScript class names whose `new` invocations
+	// in a Pulumi project denote a Lambda-backed microservice (extracted as a
+	// MicroserviceDef). Empty by default — set to e.g.
+	// ["MyCorpLambdaModuleResource"] to wire your own pattern.
+	IaCMicroserviceClasses []string `yaml:"iac_microservice_classes" json:"iac_microservice_classes"`
 }
 
 // SCMConfig holds source code management integration configuration.

--- a/pkg/iac/pulumi.go
+++ b/pkg/iac/pulumi.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/Viridian-Inc/cloudmock/pkg/service"
 )
@@ -214,8 +215,9 @@ func ImportPulumiDir(dir string, environment string, logger *slog.Logger) (*IaCI
 			}
 		}
 
-		// Lambda endpoint microservices (AutotendLambdaEndpointModuleResource)
-		if strings.Contains(src, "AutotendLambdaEndpointModuleResource") && strings.Contains(src, "name:") {
+		// Lambda endpoint microservices — only extracted when the user has
+		// registered one or more class names via SetMicroserviceClasses.
+		if sourceMatchesMicroserviceClass(src) && strings.Contains(src, "name:") {
 			microservices := parseLambdaEndpoints(src, environment)
 			if len(microservices) > 0 {
 				logger.Info("found Lambda endpoint microservices in IaC", "file", path, "count", len(microservices))
@@ -523,45 +525,88 @@ func extractLSIs(block string) []LSIDef {
 	return lsis
 }
 
-// parseLambdaEndpoints extracts AutotendLambdaEndpointModuleResource definitions.
-// These are the high-level microservice definitions with name and table dependencies.
+// microserviceClasses holds the user-registered TypeScript class names that
+// denote a Lambda-backed microservice in a Pulumi project. Empty means no
+// microservice extraction (the generic default).
+var (
+	microserviceClassesMu sync.RWMutex
+	microserviceClasses   []string
+)
+
+// SetMicroserviceClasses configures which `new <Class>(...)` TypeScript
+// invocations parseLambdaEndpoints should treat as microservice definitions.
+// Pass nil or [] to disable microservice extraction. Safe to call once at
+// startup.
+func SetMicroserviceClasses(classes []string) {
+	microserviceClassesMu.Lock()
+	defer microserviceClassesMu.Unlock()
+	microserviceClasses = append([]string(nil), classes...)
+}
+
+func getMicroserviceClasses() []string {
+	microserviceClassesMu.RLock()
+	defer microserviceClassesMu.RUnlock()
+	return microserviceClasses
+}
+
+// sourceMatchesMicroserviceClass returns true if src contains any registered
+// microservice class name. Cheap pre-filter before the regex pass.
+func sourceMatchesMicroserviceClass(src string) bool {
+	for _, class := range getMicroserviceClasses() {
+		if strings.Contains(src, class) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseLambdaEndpoints extracts microservice definitions from `new <Class>(...)`
+// invocations whose class name has been registered via SetMicroserviceClasses.
+// Each match is expected to take the shape:
+//
+//	new <Class>(`some-resource-name`, { name: "service-name", allowedTables: [tables.foo, tables.bar], ... })
 func parseLambdaEndpoints(src string, env string) []MicroserviceDef {
 	var services []MicroserviceDef
-	// Match: new AutotendLambdaEndpointModuleResource(`autotend-lep-NAME-env`, { name: "NAME", ...
-	pattern := regexp.MustCompile(`new\s+AutotendLambdaEndpointModuleResource\s*\(\s*` + "`" + `[^` + "`" + `]+` + "`" + `\s*,\s*\{`)
-	matches := pattern.FindAllStringIndex(src, -1)
+	classes := getMicroserviceClasses()
+	if len(classes) == 0 {
+		return services
+	}
 
-	for _, match := range matches {
-		blockStart := match[1] - 1
-		blockEnd := findMatchingBrace(src, blockStart)
-		if blockEnd < 0 {
-			continue
-		}
-		block := src[blockStart : blockEnd+1]
+	tablePattern := regexp.MustCompile(`tables\.(\w+)`)
 
-		// Extract name
-		name := extractStringField(block, "name")
-		if name == "" {
-			continue
-		}
+	for _, class := range classes {
+		pattern := regexp.MustCompile(`new\s+` + regexp.QuoteMeta(class) + `\s*\(\s*` + "`" + `[^` + "`" + `]+` + "`" + `\s*,\s*\{`)
+		matches := pattern.FindAllStringIndex(src, -1)
 
-		// Extract table dependencies from allowedTables array
-		var tables []string
-		tablePattern := regexp.MustCompile(`tables\.(\w+)`)
-		if atStart := strings.Index(block, "allowedTables:"); atStart >= 0 {
-			atEnd := strings.Index(block[atStart:], "]")
-			if atEnd > 0 {
-				atBlock := block[atStart : atStart+atEnd]
-				for _, tm := range tablePattern.FindAllStringSubmatch(atBlock, -1) {
-					tables = append(tables, tm[1]+"-"+env)
+		for _, match := range matches {
+			blockStart := match[1] - 1
+			blockEnd := findMatchingBrace(src, blockStart)
+			if blockEnd < 0 {
+				continue
+			}
+			block := src[blockStart : blockEnd+1]
+
+			name := extractStringField(block, "name")
+			if name == "" {
+				continue
+			}
+
+			var tables []string
+			if atStart := strings.Index(block, "allowedTables:"); atStart >= 0 {
+				atEnd := strings.Index(block[atStart:], "]")
+				if atEnd > 0 {
+					atBlock := block[atStart : atStart+atEnd]
+					for _, tm := range tablePattern.FindAllStringSubmatch(atBlock, -1) {
+						tables = append(tables, tm[1]+"-"+env)
+					}
 				}
 			}
-		}
 
-		services = append(services, MicroserviceDef{
-			Name:   name,
-			Tables: tables,
-		})
+			services = append(services, MicroserviceDef{
+				Name:   name,
+				Tables: tables,
+			})
+		}
 	}
 	return services
 }

--- a/pkg/iac/pulumi_test.go
+++ b/pkg/iac/pulumi_test.go
@@ -171,3 +171,75 @@ func TestImportPulumiDir(t *testing.T) {
 		t.Logf("  %s (pk=%s sk=%s gsis=%d lsis=%d)", table.Name, table.HashKey, table.RangeKey, len(table.GSIs), len(table.LSIs))
 	}
 }
+
+const microserviceFixtureSrc = "this.bff = new MyCorpLambdaModuleResource(`mycorp-lep-bff-dev`, {\n" +
+	"  name: \"bff\",\n" +
+	"  allowedTables: [tables.membership, tables.session],\n" +
+	"});\n" +
+	"this.attendance = new MyCorpLambdaModuleResource(`mycorp-lep-attendance-dev`, {\n" +
+	"  name: \"attendance\",\n" +
+	"  allowedTables: [tables.attendance],\n" +
+	"});\n"
+
+func TestParseLambdaEndpoints_NoClassesRegistered(t *testing.T) {
+	SetMicroserviceClasses(nil)
+	t.Cleanup(func() { SetMicroserviceClasses(nil) })
+
+	got := parseLambdaEndpoints(microserviceFixtureSrc, "dev")
+	if len(got) != 0 {
+		t.Errorf("expected empty result with no classes registered, got %d", len(got))
+	}
+}
+
+func TestParseLambdaEndpoints_RegisteredClass(t *testing.T) {
+	SetMicroserviceClasses([]string{"MyCorpLambdaModuleResource"})
+	t.Cleanup(func() { SetMicroserviceClasses(nil) })
+
+	got := parseLambdaEndpoints(microserviceFixtureSrc, "dev")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 microservices, got %d: %+v", len(got), got)
+	}
+
+	byName := map[string]MicroserviceDef{}
+	for _, ms := range got {
+		byName[ms.Name] = ms
+	}
+
+	bff, ok := byName["bff"]
+	if !ok {
+		t.Fatalf("expected 'bff' microservice, got %v", byName)
+	}
+	if want := []string{"membership-dev", "session-dev"}; !equalStringSlices(bff.Tables, want) {
+		t.Errorf("bff.Tables = %v, want %v", bff.Tables, want)
+	}
+
+	attendance, ok := byName["attendance"]
+	if !ok {
+		t.Fatalf("expected 'attendance' microservice, got %v", byName)
+	}
+	if want := []string{"attendance-dev"}; !equalStringSlices(attendance.Tables, want) {
+		t.Errorf("attendance.Tables = %v, want %v", attendance.Tables, want)
+	}
+}
+
+func TestParseLambdaEndpoints_UnregisteredClassIgnored(t *testing.T) {
+	SetMicroserviceClasses([]string{"OtherCorpLambdaResource"})
+	t.Cleanup(func() { SetMicroserviceClasses(nil) })
+
+	got := parseLambdaEndpoints(microserviceFixtureSrc, "dev")
+	if len(got) != 0 {
+		t.Errorf("expected 0 microservices when registered class doesn't match, got %d", len(got))
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Closes the last brand-leak from PR #36: \`pkg/iac/pulumi.go\`'s microservice extraction was keyed off the hardcoded TypeScript class name \`AutotendLambdaEndpointModuleResource\`. Replaces the literal with a configurable list, mirroring the \`gateway.SetServicePrefixes\` pattern.

- \`Config.IaCMicroserviceClasses []string\` (yaml \`iac_microservice_classes\`), empty by default.
- \`iac.SetMicroserviceClasses([]string)\` package-level setter, RWMutex-guarded.
- \`parseLambdaEndpoints\` iterates registered classes; per-class regex built with \`regexp.QuoteMeta\`.
- Trigger condition in \`ImportPulumiDir\` becomes \`sourceMatchesMicroserviceClass(src)\`.
- \`cmd/gateway/main.go\` wires \`iac.SetMicroserviceClasses(cfg.IaCMicroserviceClasses)\` at startup.
- \`cloudmock.yml\` documents the optional field.

Closes #41.

## Behavior change

Empty default = no microservices extracted (the right answer for a generic tool). Existing autotend setups need:

\`\`\`yaml
iac_microservice_classes:
  - AutotendLambdaEndpointModuleResource
\`\`\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/iac/... ./pkg/config/... ./pkg/gateway/... ./pkg/admin/... ./cmd/gateway/...\` — all green
- [x] \`go vet ./pkg/iac/... ./pkg/config/... ./cmd/gateway/...\`
- [x] Three new tests cover the empty / registered-and-matching / registered-but-not-matching shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)