### PR TITLE
refactor(cloudmock-dns): rename domainConfig.Autotend → Primary

### DIFF
--- a/tools/cloudmock-dns/config_test.go
+++ b/tools/cloudmock-dns/config_test.go
@@ -10,7 +10,7 @@ func TestParsePulumiConfig(t *testing.T) {
 	yaml := `config:
   backend:environment: local
   backend:domains:
-    autotend: custom.example.com
+    primary: custom.example.com
     cloudmock: mock.example.com
 `
 	tmp := filepath.Join(t.TempDir(), "Pulumi.local.yaml")
@@ -20,11 +20,49 @@ func TestParsePulumiConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if dc.Autotend != "custom.example.com" {
-		t.Errorf("expected custom.example.com, got %s", dc.Autotend)
+	if dc.Primary != "custom.example.com" {
+		t.Errorf("expected custom.example.com, got %s", dc.Primary)
 	}
 	if dc.Cloudmock != "mock.example.com" {
 		t.Errorf("expected mock.example.com, got %s", dc.Cloudmock)
+	}
+}
+
+func TestParsePulumiConfig_LegacyAutotendKey(t *testing.T) {
+	// Existing autotend-infra Pulumi configs use the "autotend" key for the
+	// primary domain. Verify the legacy alias still maps to dc.Primary.
+	yaml := `config:
+  backend:environment: local
+  backend:domains:
+    autotend: legacy.example.com
+    cloudmock: mock.example.com
+`
+	tmp := filepath.Join(t.TempDir(), "Pulumi.local.yaml")
+	os.WriteFile(tmp, []byte(yaml), 0644)
+
+	dc, err := parsePulumiConfig(tmp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dc.Primary != "legacy.example.com" {
+		t.Errorf("expected legacy.example.com from autotend alias, got %s", dc.Primary)
+	}
+}
+
+func TestParsePulumiConfig_PrimaryWinsOverLegacy(t *testing.T) {
+	// If both keys are set, "primary" wins.
+	yaml := `config:
+  backend:domains:
+    primary: new.example.com
+    autotend: old.example.com
+    cloudmock: mock.example.com
+`
+	tmp := filepath.Join(t.TempDir(), "Pulumi.local.yaml")
+	os.WriteFile(tmp, []byte(yaml), 0644)
+
+	dc, _ := parsePulumiConfig(tmp)
+	if dc.Primary != "new.example.com" {
+		t.Errorf("expected primary key to win, got %s", dc.Primary)
 	}
 }
 
@@ -33,14 +71,14 @@ func TestParsePulumiConfigMissing(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for missing file")
 	}
-	if dc.Autotend != "cloudmock.app" || dc.Cloudmock != "cloudmock.app" {
+	if dc.Primary != "cloudmock.app" || dc.Cloudmock != "cloudmock.app" {
 		t.Errorf("expected default domains, got %+v", dc)
 	}
 }
 
 func TestParsePulumiConfigNoDomains(t *testing.T) {
 	yaml := `config:
-  autotend-backend:environment: local
+  backend:environment: local
 `
 	tmp := filepath.Join(t.TempDir(), "Pulumi.local.yaml")
 	os.WriteFile(tmp, []byte(yaml), 0644)
@@ -49,7 +87,7 @@ func TestParsePulumiConfigNoDomains(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when domains key is missing")
 	}
-	if dc.Autotend != "cloudmock.app" || dc.Cloudmock != "cloudmock.app" {
+	if dc.Primary != "cloudmock.app" || dc.Cloudmock != "cloudmock.app" {
 		t.Errorf("expected default domains, got %+v", dc)
 	}
 }

--- a/tools/cloudmock-dns/main.go
+++ b/tools/cloudmock-dns/main.go
@@ -21,12 +21,12 @@ const resolverDir = "/etc/resolver"
 const baseDNSPort = 15353
 
 type domainConfig struct {
-	Autotend  string
+	Primary   string
 	Cloudmock string
 }
 
 var defaultDomains = domainConfig{
-	Autotend:  "cloudmock.app",
+	Primary:   "cloudmock.app",
 	Cloudmock: "cloudmock.app",
 }
 
@@ -50,8 +50,12 @@ func parsePulumiConfig(path string) (domainConfig, error) {
 		return defaultDomains, fmt.Errorf("domains is not a map in %s", path)
 	}
 	dc := defaultDomains
-	if v, ok := domainsMap["autotend"].(string); ok {
-		dc.Autotend = v
+	// "primary" is the canonical key; "autotend" is accepted as a legacy
+	// alias so existing autotend-infra Pulumi configs keep working.
+	if v, ok := domainsMap["primary"].(string); ok {
+		dc.Primary = v
+	} else if v, ok := domainsMap["autotend"].(string); ok {
+		dc.Primary = v
 	}
 	if v, ok := domainsMap["cloudmock"].(string); ok {
 		dc.Cloudmock = v
@@ -61,7 +65,7 @@ func parsePulumiConfig(path string) (domainConfig, error) {
 
 func (dc domainConfig) sortedDomains() []struct{ key, domain string } {
 	pairs := []struct{ key, domain string }{
-		{"cloudmock", dc.Autotend},
+		{"primary", dc.Primary},
 		{"cloudmock", dc.Cloudmock},
 	}
 	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
@@ -81,16 +85,16 @@ func (dc domainConfig) resolverEntries() []struct{ path, content string } {
 }
 
 func (dc domainConfig) hostsEntries() []string {
-	at := "localhost." + dc.Autotend
+	primary := "localhost." + dc.Primary
 	cm := "localhost." + dc.Cloudmock
 	return []string{
-		"127.0.0.1  " + at,
-		"127.0.0.1  app." + at,
-		"127.0.0.1  bff." + at,
-		"127.0.0.1  api." + at,
-		"127.0.0.1  auth." + at,
-		"127.0.0.1  admin." + at,
-		"127.0.0.1  graphql." + at,
+		"127.0.0.1  " + primary,
+		"127.0.0.1  app." + primary,
+		"127.0.0.1  bff." + primary,
+		"127.0.0.1  api." + primary,
+		"127.0.0.1  auth." + primary,
+		"127.0.0.1  admin." + primary,
+		"127.0.0.1  graphql." + primary,
 		"127.0.0.1  " + cm,
 	}
 }
@@ -243,7 +247,7 @@ func autoSetupLinux(dc domainConfig) {
 	fmt.Println("  Create /etc/systemd/resolved.conf.d/cloudmock.conf:")
 	fmt.Println("    [Resolve]")
 	fmt.Println("    DNS=127.0.0.1")
-	fmt.Printf("    Domains=~%s ~%s\n", dc.Autotend, dc.Cloudmock)
+	fmt.Printf("    Domains=~%s ~%s\n", dc.Primary, dc.Cloudmock)
 	fmt.Println("  Then: sudo systemctl restart systemd-resolved")
 	fmt.Println()
 	fmt.Println("Option B — /etc/hosts (no cloudmock DNS needed):")
@@ -263,7 +267,7 @@ func internalResolverSetup(dc domainConfig) {
 }
 
 func printLocalDomains(dc domainConfig) {
-	at := dc.Autotend
+	at := dc.Primary
 	cm := dc.Cloudmock
 	fmt.Println()
 	fmt.Println("  Zero-config (works immediately, no setup needed):")
@@ -313,7 +317,7 @@ func setup(dc domainConfig) {
 	for _, e := range entries {
 		fmt.Printf("  %s\n", e)
 	}
-	fmt.Printf("\nYou can now access: http://localhost.%s\n", dc.Autotend)
+	fmt.Printf("\nYou can now access: http://localhost.%s\n", dc.Primary)
 	fmt.Println("\nTip: 'cloudmock-dns auto' sets up a DNS resolver instead (no /etc/hosts needed).")
 }
 
@@ -353,7 +357,7 @@ func remove(dc domainConfig) {
 			}
 			if inBlock {
 				if strings.HasPrefix(strings.TrimSpace(line), "127.0.0.1") &&
-					(strings.Contains(line, "localhost."+dc.Autotend) || strings.Contains(line, "localhost."+dc.Cloudmock)) {
+					(strings.Contains(line, "localhost."+dc.Primary) || strings.Contains(line, "localhost."+dc.Cloudmock)) {
 					continue
 				}
 				if strings.TrimSpace(line) == "" {


### PR DESCRIPTION
## Summary

Last remaining brand-leak in non-test Go. \`tools/cloudmock-dns/main.go\` owned a \`domainConfig\` struct field named \`Autotend\` (with default value \`cloudmock.app\`), and \`parsePulumiConfig\` read the primary domain from a YAML key called \`autotend\`.

- \`domainConfig.Autotend\` → \`Primary\`. All call sites updated.
- \`parsePulumiConfig\` accepts \`primary\` as canonical, falls back to \`autotend\` for backwards compat with existing autotend-infra Pulumi configs.
- Three new test cases pin the legacy alias, the precedence when both keys are set, and the renamed canonical case.

Closes #49.

## Out of scope

The remaining \`autotend\` mentions in non-test Go (a parser example comment in \`pkg/iac/pulumi.go\` and the alias-justification comment in \`pkg/gateway/proxy.go\`) are accurate descriptive context — left as-is.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./tools/cloudmock-dns/...\` — green, including the three new cases
- [x] \`go vet ./tools/cloudmock-dns/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)