### PR TITLE
fix(docker): pin devtools build to pnpm 9 (fixes publish-docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build devtools UI
 FROM node:22-alpine AS dashboard
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Pin pnpm to v9 to match the release pipeline's build-devtools job
+# (pnpm/action-setup version: 9) and the lockfileVersion 9.0 lockfile.
+# Using pnpm@latest here let a newer major (pnpm 10+, with stricter
+# build-script/supply-chain gating) break `pnpm install --frozen-lockfile`.
+RUN corepack enable && corepack prepare pnpm@9 --activate
 WORKDIR /devtools
 COPY devtools/package.json devtools/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
## Why

`publish-docker` failed in the **v1.9.0** release. Root cause: `Dockerfile` built the devtools stage with `corepack prepare pnpm@latest`, which floats to the newest pnpm major at build time. A pnpm 10+ release (stricter build-script / supply-chain gating) makes `pnpm install --frozen-lockfile` exit 1.

The release pipeline's `build-devtools` job pins **pnpm 9** (`pnpm/action-setup` `version: 9`) and the lockfile is `lockfileVersion: 9.0`, so the pinned path builds fine — only the Docker image used the unpinned floating version.

## Fix

Pin the Dockerfile devtools stage to `pnpm@9` to match the rest of the pipeline and the lockfile.

## Verification

CI here is Go-only and does **not** build the Docker image, so this was verified by building the `dashboard` stage locally (`docker build --target dashboard`) with the pinned pnpm. Confirms `pnpm install --frozen-lockfile` succeeds.

Once merged, the fix ships in the next release tag (v1.9.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)