### PR TITLE
feat(state): named --project flag + "delete local data" UI

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -344,6 +344,32 @@ func writeStateAtomic(path string, data []byte) error {
 	return os.Rename(tmp, path)
 }
 
+// sanitizeProjectName reduces a user-supplied project/database name to a
+// single safe path segment (no directory traversal, only [A-Za-z0-9._-]).
+// Returns "" for an empty or unusable name.
+func sanitizeProjectName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	// Collapse any path components so "../x" or "a/b" can't escape the
+	// projects directory.
+	name = filepath.Base(name)
+	if name == "." || name == ".." || name == string(filepath.Separator) {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
 func main() {
 	// Initialize structured logging. JSON in production, text for local dev.
 	logFormat := os.Getenv("CLOUDMOCK_LOG_FORMAT")
@@ -364,6 +390,7 @@ func main() {
 	iacEnv := flag.String("iac-env", "dev", "environment name for IaC resource name resolution (e.g., dev, stage, prod)")
 	stateFile := flag.String("state", "", "path to cloudmock state JSON file for snapshot restore/save (env: CLOUDMOCK_STATE)")
 	stateInterval := flag.Duration("state-interval", 5*time.Second, "disk mode: how often to persist state to -state; 0 = only on graceful shutdown (env: CLOUDMOCK_STATE_INTERVAL)")
+	projectName := flag.String("project", "", "named project/database for persistent storage; roots all on-disk data under ~/.cloudmock/projects/<name>/ and enables disk persistence by default (env: CLOUDMOCK_PROJECT)")
 	flag.Parse()
 
 	// Allow env var override for state file.
@@ -378,6 +405,31 @@ func main() {
 		} else {
 			slog.Warn("invalid CLOUDMOCK_STATE_INTERVAL; ignoring", "value", v, "error", perr)
 		}
+	}
+
+	// Resolve the named project (flag --project, env CLOUDMOCK_PROJECT). A
+	// named project roots ALL on-disk persistence under
+	// ~/.cloudmock/projects/<name>/ and enables disk persistence by default.
+	// The shared plugins/ directory stays at ~/.cloudmock/plugins/ (binaries,
+	// not project data) so it survives a "wipe local data".
+	if *projectName == "" {
+		*projectName = os.Getenv("CLOUDMOCK_PROJECT")
+	}
+	*projectName = sanitizeProjectName(*projectName)
+
+	cloudmockHome := filepath.Join(os.Getenv("HOME"), ".cloudmock")
+	dataDir := cloudmockHome
+	if *projectName != "" {
+		dataDir = filepath.Join(cloudmockHome, "projects", *projectName)
+		if err := os.MkdirAll(dataDir, 0o755); err != nil {
+			slog.Error("failed to create project data directory", "dir", dataDir, "error", err)
+		}
+		// Naming a project turns on disk mode: persist to its own state file
+		// unless an explicit -state path (or CLOUDMOCK_STATE) was given.
+		if *stateFile == "" {
+			*stateFile = filepath.Join(dataDir, "state.json")
+		}
+		slog.Info("named project", "project", *projectName, "data_dir", dataDir, "state", *stateFile)
 	}
 
 	// Auto-detect state/seed file from .cloudmock/ in the working
@@ -1126,8 +1178,9 @@ func main() {
 		dp.Requests = tenantscope.NewRequestReader(dp.Requests)
 	}
 
-	// Base directory for file-backed stores.
-	baseDir := filepath.Join(os.Getenv("HOME"), ".cloudmock")
+	// Base directory for file-backed stores. With a named project this is
+	// ~/.cloudmock/projects/<name>/, otherwise ~/.cloudmock (see dataDir).
+	baseDir := dataDir
 
 	// Chaos engine for fault injection — file-backed.
 	// In minimal profile, skip disk I/O for chaos rules (no rules by default).
@@ -1180,6 +1233,20 @@ func main() {
 	} else {
 		adminAPI.SetPersistDir(baseDir)
 	}
+	// Tell the admin API about this instance's on-disk footprint so the
+	// /api/local-data endpoints can report and wipe it. The subdir list is
+	// the set of data directories cloudmock manages under baseDir; plugins/
+	// is intentionally excluded so a wipe never deletes plugin binaries.
+	adminAPI.SetLocalData(admin.LocalData{
+		Project:   *projectName,
+		Dir:       baseDir,
+		StateFile: *stateFile,
+		Subdirs: []string{
+			"chaos", "rum", "replay", "uptime", "errors", "logs",
+			"incidents", "monitors", "alerts", "traffic", "annotations",
+			"cicd", "synthetics", "dashboards", "views", "deploys",
+		},
+	})
 	// Also set the direct request log/stats for topology edge enrichment
 	adminAPI.SetRequestLog(requestLog, requestStats)
 

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestSanitizeProjectName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"myapp", "myapp"},
+		{"My_App-1.2", "My_App-1.2"},
+		{"  trimmed  ", "trimmed"},
+		// Path traversal / separators must be neutralized to a single segment.
+		{"../../etc", "etc"},
+		{"a/b/c", "c"},
+		{"..", ""},
+		{".", ""},
+		{"/", ""},
+		// Unsafe characters become '-'.
+		{"a b$c", "a-b-c"},
+		{"team:proj", "team-proj"},
+	}
+	for _, tc := range tests {
+		if got := sanitizeProjectName(tc.in); got != tc.want {
+			t.Errorf("sanitizeProjectName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/devtools/src/lib/api.ts
+++ b/devtools/src/lib/api.ts
@@ -139,3 +139,30 @@ export function resetService(name?: string): Promise<void> {
   const path = name ? `/api/reset?service=${encodeURIComponent(name)}` : '/api/reset';
   return api<void>(path, { method: 'POST' });
 }
+
+/** On-disk persistence footprint of the running cloudmock instance. */
+export interface LocalDataInfo {
+  project: string;
+  dir: string;
+  stateFile: string;
+  persistent: boolean;
+  onDisk: boolean;
+}
+
+/** Result of wiping all locally-stored on-disk data. */
+export interface LocalDataDeleteResult {
+  status: string;
+  project: string;
+  dir: string;
+  removed: string[];
+  reset_services: string[];
+  failures?: string[];
+}
+
+export function getLocalDataInfo(): Promise<LocalDataInfo> {
+  return api<LocalDataInfo>('/api/local-data');
+}
+
+export function deleteLocalData(): Promise<LocalDataDeleteResult> {
+  return api<LocalDataDeleteResult>('/api/local-data/delete', { method: 'POST' });
+}

--- a/devtools/src/views/settings/index.tsx
+++ b/devtools/src/views/settings/index.tsx
@@ -7,9 +7,10 @@ import { Domains } from './domains';
 import { Account } from './account';
 import { Webhooks } from './webhooks';
 import { Audit } from './audit';
+import { LocalData } from './local-data';
 import './settings.css';
 
-type Tab = 'connections' | 'routing' | 'domains' | 'webhooks' | 'config' | 'appearance' | 'audit' | 'account';
+type Tab = 'connections' | 'routing' | 'domains' | 'webhooks' | 'config' | 'appearance' | 'audit' | 'account' | 'local-data';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'connections', label: 'Connections' },
@@ -20,6 +21,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'appearance', label: 'Appearance' },
   { id: 'audit', label: 'Audit' },
   { id: 'account', label: 'Account' },
+  { id: 'local-data', label: 'Local Data' },
 ];
 
 const TAB_IDS = new Set<Tab>(TABS.map((t) => t.id));
@@ -51,6 +53,7 @@ export function SettingsView() {
         {activeTab === 'appearance' && <Appearance />}
         {activeTab === 'audit' && <Audit />}
         {activeTab === 'account' && <Account />}
+        {activeTab === 'local-data' && <LocalData />}
       </div>
     </div>
   );

--- a/devtools/src/views/settings/local-data.tsx
+++ b/devtools/src/views/settings/local-data.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect, useCallback } from 'preact/hooks';
+import {
+  getLocalDataInfo,
+  deleteLocalData,
+  type LocalDataInfo,
+  type LocalDataDeleteResult,
+} from '../../lib/api';
+
+const UNNAMED = '(unnamed — default ~/.cloudmock)';
+
+export function LocalData() {
+  const [info, setInfo] = useState<LocalDataInfo | null>(null);
+  const [loadError, setLoadError] = useState('');
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [actionError, setActionError] = useState('');
+  const [result, setResult] = useState<LocalDataDeleteResult | null>(null);
+
+  const refresh = useCallback(() => {
+    getLocalDataInfo()
+      .then((d) => {
+        setInfo(d);
+        setLoadError('');
+      })
+      .catch((e) => setLoadError(String(e?.message ?? e)));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleConfirmDelete = useCallback(() => {
+    setDeleting(true);
+    setActionError('');
+    deleteLocalData()
+      .then((r) => {
+        setResult(r);
+        setShowConfirm(false);
+        refresh();
+      })
+      .catch((e) => setActionError(String(e?.message ?? e)))
+      .finally(() => setDeleting(false));
+  }, [refresh]);
+
+  const projectLabel = info?.project ? info.project : UNNAMED;
+
+  return (
+    <div class="settings-section">
+      <h3 class="settings-section-title">Local Data</h3>
+      <p class="settings-section-desc">
+        On-disk persistent storage for this cloudmock project. Deleting wipes all
+        locally stored data for this project and resets in-memory state — installed
+        plugins and other projects are not affected.
+      </p>
+
+      {loadError && <p class="settings-error">{loadError}</p>}
+
+      <div class="settings-field">
+        <label class="settings-label">Project / Database</label>
+        <span class="settings-status-label" style="font-size: 12px;">
+          {projectLabel}
+        </span>
+      </div>
+
+      <div class="settings-field">
+        <label class="settings-label">Data Directory</label>
+        <code class="settings-code">{info?.dir || '—'}</code>
+      </div>
+
+      <div class="settings-field">
+        <label class="settings-label">Persistence</label>
+        <div class="settings-field-row">
+          <span
+            class={`settings-status-dot ${info?.persistent ? 'connected' : 'disconnected'}`}
+          />
+          <span class="settings-status-label" style="font-size: 12px;">
+            {info?.persistent
+              ? `Enabled → ${info.stateFile}`
+              : 'In-memory only (no disk persistence)'}
+          </span>
+        </div>
+      </div>
+
+      {result && (
+        <p
+          class="settings-status-label"
+          style="font-size: 12px; color: var(--text-secondary); margin-top: 8px;"
+        >
+          Deleted {result.removed?.length ?? 0} path(s) and reset{' '}
+          {result.reset_services?.length ?? 0} service(s).
+          {result.failures && result.failures.length > 0
+            ? ` ${result.failures.length} path(s) failed to delete.`
+            : ''}
+        </p>
+      )}
+
+      <div class="settings-actions">
+        <button
+          class="btn settings-btn-danger"
+          disabled={!info?.onDisk}
+          title={info?.onDisk ? '' : 'Nothing is stored on disk for this project'}
+          onClick={() => {
+            setResult(null);
+            setActionError('');
+            setShowConfirm(true);
+          }}
+        >
+          Delete all local data
+        </button>
+      </div>
+
+      {showConfirm && (
+        <div
+          class="settings-modal-overlay"
+          onClick={() => {
+            if (!deleting) setShowConfirm(false);
+          }}
+        >
+          <div class="settings-modal" onClick={(e) => e.stopPropagation()}>
+            <div class="settings-modal-header">
+              <span class="settings-modal-title">Delete all local data?</span>
+            </div>
+            <div class="settings-modal-body">
+              <p style="font-size: 13px; margin: 0 0 12px; color: var(--text-primary);">
+                This permanently deletes all locally stored on-disk data for project{' '}
+                <strong>{projectLabel}</strong> and resets in-memory service state.
+                This cannot be undone.
+              </p>
+              <code class="settings-code">{info?.dir}</code>
+              {actionError && (
+                <p class="settings-error" style="margin-top: 12px; margin-bottom: 0;">
+                  {actionError}
+                </p>
+              )}
+            </div>
+            <div class="settings-modal-footer">
+              <button
+                class="btn"
+                disabled={deleting}
+                onClick={() => setShowConfirm(false)}
+              >
+                Cancel
+              </button>
+              <button
+                class="btn settings-btn-danger"
+                disabled={deleting}
+                onClick={handleConfirmDelete}
+              >
+                {deleting ? 'Deleting…' : 'Delete everything'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/devtools/src/views/settings/settings.css
+++ b/devtools/src/views/settings/settings.css
@@ -99,6 +99,67 @@
   margin-top: 20px;
 }
 
+/* Destructive action button (e.g. delete all local data) */
+.settings-btn-danger {
+  border-color: rgba(255, 78, 94, 0.4);
+  color: var(--error);
+}
+
+.settings-btn-danger:hover:not(:disabled) {
+  background: rgba(255, 78, 94, 0.12);
+  border-color: var(--error);
+}
+
+.settings-btn-danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Confirmation modal (shared by destructive settings actions) */
+.settings-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+}
+
+.settings-modal {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  width: 460px;
+  max-width: calc(100vw - 32px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-lg);
+}
+
+.settings-modal-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-modal-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.settings-modal-body {
+  padding: 20px;
+}
+
+.settings-modal-footer {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 /* Placeholder / loading */
 .settings-placeholder {
   color: var(--text-tertiary);

--- a/pkg/admin/api.go
+++ b/pkg/admin/api.go
@@ -161,6 +161,7 @@ type API struct {
 	marketplace        *marketplace.Registry
 	persistDir         string       // if set, dashboards/views/deploys are persisted here
 	dynamoStore        *DynamoStore // if set, dashboards/views/deploys use DynamoDB
+	localData          *LocalData   // on-disk persistence footprint for /api/local-data
 	platform           *PlatformStore
 	platformApps       *platformstore.AppStore
 	platformKeys       *platformstore.APIKeyStore
@@ -367,6 +368,8 @@ func New(cfg *config.Config, registry *routing.Registry, log *gateway.RequestLog
 	a.mux.HandleFunc("/api/state/export", a.handleStateExport)
 	a.mux.HandleFunc("/api/state/import", a.handleStateImport)
 	a.mux.HandleFunc("/api/state/reset", a.handleStateReset)
+	a.mux.HandleFunc("/api/local-data", a.handleLocalDataInfo)
+	a.mux.HandleFunc("/api/local-data/delete", a.handleLocalDataDelete)
 
 	// CloudTrail replay endpoint
 	a.mux.HandleFunc("/api/cloudtrail/replay", a.handleCloudTrailReplay)
@@ -528,6 +531,8 @@ func NewWithDataPlane(cfg *config.Config, registry *routing.Registry, dp *datapl
 	a.mux.HandleFunc("/api/state/export", a.handleStateExport)
 	a.mux.HandleFunc("/api/state/import", a.handleStateImport)
 	a.mux.HandleFunc("/api/state/reset", a.handleStateReset)
+	a.mux.HandleFunc("/api/local-data", a.handleLocalDataInfo)
+	a.mux.HandleFunc("/api/local-data/delete", a.handleLocalDataDelete)
 
 	// CloudTrail replay endpoint
 	a.mux.HandleFunc("/api/cloudtrail/replay", a.handleCloudTrailReplay)

--- a/pkg/admin/local_data.go
+++ b/pkg/admin/local_data.go
@@ -1,0 +1,146 @@
+package admin
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/Viridian-Inc/cloudmock/pkg/service"
+)
+
+// LocalData describes the on-disk persistence footprint of the running
+// cloudmock instance: its named project, the root data directory, the snapshot
+// state file, and the data subdirectories cloudmock manages under the data
+// directory. It is set from the gateway at startup via SetLocalData and powers
+// the /api/local-data endpoints (report + wipe). The shared plugins/ directory
+// is deliberately NOT included so a wipe never deletes plugin binaries.
+type LocalData struct {
+	Project   string   // project/database name; "" when unnamed (default ~/.cloudmock)
+	Dir       string   // root data directory (baseDir)
+	StateFile string   // snapshot file path; "" when disk persistence is off
+	Subdirs   []string // data subdirectories under Dir that a wipe may remove
+}
+
+// SetLocalData records this instance's on-disk persistence footprint for the
+// /api/local-data endpoints.
+func (a *API) SetLocalData(ld LocalData) {
+	a.localData = &ld
+}
+
+// handleLocalDataInfo reports the current project/database name, data
+// directory, and whether disk persistence is active. GET /api/local-data.
+func (a *API) handleLocalDataInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	ld := a.localData
+	if ld == nil || ld.Dir == "" {
+		// No data directory configured → fully in-memory.
+		writeJSON(w, http.StatusOK, map[string]any{
+			"project":    "",
+			"dir":        "",
+			"stateFile":  "",
+			"persistent": false,
+			"onDisk":     false,
+		})
+		return
+	}
+	onDisk := false
+	if _, err := os.Stat(ld.Dir); err == nil {
+		onDisk = true
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"project":    ld.Project,
+		"dir":        ld.Dir,
+		"stateFile":  ld.StateFile,
+		"persistent": ld.StateFile != "",
+		"onDisk":     onDisk,
+	})
+}
+
+// handleLocalDataDelete wipes all locally-stored on-disk data for the current
+// project/instance: it resets in-memory service state, clears admin
+// dashboards/views/deploys, removes the snapshot state file, and deletes the
+// managed data subdirectories (recreating them empty so the running stores
+// keep working). The shared plugins/ directory is never touched, and other
+// named projects on disk are left intact. POST /api/local-data/delete.
+func (a *API) handleLocalDataDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	ld := a.localData
+	if ld == nil || ld.Dir == "" {
+		writeError(w, http.StatusConflict, "no local data directory configured (running in-memory)")
+		return
+	}
+
+	// 1. Reset in-memory service state (snapshotable services), mirroring
+	//    /api/state/reset so the live server is empty after the wipe.
+	var resetServices []string
+	for _, svc := range a.registry.All() {
+		if snap, ok := svc.(service.Snapshotable); ok {
+			_ = snap.ImportState([]byte("{}"))
+			resetServices = append(resetServices, svc.Name())
+		}
+	}
+
+	// 2. Clear admin in-memory dashboards/views/deploys.
+	a.dashboardsMu.Lock()
+	a.dashboards = nil
+	a.dashboardsMu.Unlock()
+	a.viewsMu.Lock()
+	a.views = nil
+	a.viewsMu.Unlock()
+	a.deploysMu.Lock()
+	a.deploys = nil
+	a.deploysMu.Unlock()
+
+	// 3. Remove on-disk data: the snapshot file (+ its atomic .tmp sibling)
+	//    and each managed subdirectory. plugins/ is never in Subdirs.
+	var removed, failures []string
+	if ld.StateFile != "" {
+		for _, f := range []string{ld.StateFile, ld.StateFile + ".tmp"} {
+			if err := os.Remove(f); err == nil {
+				removed = append(removed, f)
+			} else if !os.IsNotExist(err) {
+				failures = append(failures, f+": "+err.Error())
+			}
+		}
+	}
+	for _, sub := range ld.Subdirs {
+		if sub == "" {
+			continue
+		}
+		dir := filepath.Join(ld.Dir, sub)
+		if err := os.RemoveAll(dir); err != nil {
+			failures = append(failures, dir+": "+err.Error())
+			continue
+		}
+		removed = append(removed, dir)
+		// Recreate empty so the running file-backed stores keep working.
+		_ = os.MkdirAll(dir, 0o755)
+	}
+
+	a.auditLog(r.Context(), "local_data.deleted", "state:local-data", map[string]any{
+		"project":        ld.Project,
+		"dir":            ld.Dir,
+		"removed":        len(removed),
+		"reset_services": len(resetServices),
+	})
+
+	resp := map[string]any{
+		"status":         "deleted",
+		"project":        ld.Project,
+		"dir":            ld.Dir,
+		"removed":        removed,
+		"reset_services": resetServices,
+	}
+	if len(failures) > 0 {
+		resp["failures"] = failures
+		writeJSON(w, http.StatusInternalServerError, resp)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/pkg/admin/local_data_test.go
+++ b/pkg/admin/local_data_test.go
@@ -1,0 +1,150 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Viridian-Inc/cloudmock/pkg/admin"
+)
+
+func seedFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLocalDataInfo(t *testing.T) {
+	api, _ := newTestAPI(t)
+	dir := t.TempDir()
+	api.SetLocalData(admin.LocalData{
+		Project:   "myapp",
+		Dir:       dir,
+		StateFile: filepath.Join(dir, "state.json"),
+		Subdirs:   []string{"chaos", "dashboards"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/local-data", nil)
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["project"] != "myapp" {
+		t.Errorf("project = %v, want myapp", resp["project"])
+	}
+	if resp["persistent"] != true {
+		t.Errorf("persistent = %v, want true", resp["persistent"])
+	}
+	if resp["dir"] != dir {
+		t.Errorf("dir = %v, want %s", resp["dir"], dir)
+	}
+	if resp["onDisk"] != true {
+		t.Errorf("onDisk = %v, want true", resp["onDisk"])
+	}
+}
+
+func TestLocalDataInfo_InMemory(t *testing.T) {
+	api, _ := newTestAPI(t) // no SetLocalData → in-memory
+	req := httptest.NewRequest(http.MethodGet, "/api/local-data", nil)
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["persistent"] != false {
+		t.Errorf("persistent = %v, want false for in-memory mode", resp["persistent"])
+	}
+}
+
+func TestLocalDataDelete(t *testing.T) {
+	api, _ := newTestAPI(t)
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "state.json")
+
+	// Seed on-disk data: state file (+ a stray .tmp), two managed subdirs with
+	// files, and a plugins/ dir that MUST survive the wipe.
+	seedFile(t, stateFile, `{"version":1}`)
+	seedFile(t, stateFile+".tmp", `partial`)
+	seedFile(t, filepath.Join(dir, "chaos", "r1.json"), `{}`)
+	seedFile(t, filepath.Join(dir, "dashboards", "d1.json"), `{}`)
+	seedFile(t, filepath.Join(dir, "plugins", "mybin"), `binary`)
+
+	api.SetLocalData(admin.LocalData{
+		Project:   "myapp",
+		Dir:       dir,
+		StateFile: stateFile,
+		Subdirs:   []string{"chaos", "dashboards"},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/local-data/delete", nil)
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	// State file and its .tmp sibling are gone.
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Errorf("state file still exists (err=%v)", err)
+	}
+	if _, err := os.Stat(stateFile + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("state .tmp still exists (err=%v)", err)
+	}
+
+	// Managed subdirs are recreated but empty.
+	for _, sub := range []string{"chaos", "dashboards"} {
+		entries, err := os.ReadDir(filepath.Join(dir, sub))
+		if err != nil {
+			t.Errorf("subdir %s missing after wipe: %v", sub, err)
+			continue
+		}
+		if len(entries) != 0 {
+			t.Errorf("subdir %s not empty after wipe: %d entries", sub, len(entries))
+		}
+	}
+
+	// plugins/ is preserved — a wipe must never delete plugin binaries.
+	if _, err := os.Stat(filepath.Join(dir, "plugins", "mybin")); err != nil {
+		t.Errorf("plugins/mybin was deleted by wipe (err=%v)", err)
+	}
+}
+
+func TestLocalDataDelete_NotConfigured(t *testing.T) {
+	api, _ := newTestAPI(t) // no SetLocalData
+	req := httptest.NewRequest(http.MethodPost, "/api/local-data/delete", nil)
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (in-memory, nothing to delete)", w.Code)
+	}
+}
+
+func TestLocalDataDelete_MethodNotAllowed(t *testing.T) {
+	api, _ := newTestAPI(t)
+	api.SetLocalData(admin.LocalData{Dir: t.TempDir()})
+	req := httptest.NewRequest(http.MethodGet, "/api/local-data/delete", nil)
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+}


### PR DESCRIPTION
Adds a **named project/database for persistent on-disk storage** and a **devtools UI to wipe it** — building on the disk-mode persistence from #51.

## CLI — `--project <name>` (env `CLOUDMOCK_PROJECT`)
When set, **all** on-disk persistence is rooted under `~/.cloudmock/projects/<name>/`:
- the snapshot `state.json`,
- every file-backed store (chaos, rum, replay, uptime, errors, logs, incidents, monitors, alerts, traffic, annotations, cicd, synthetics),
- admin dashboards/views/deploys.

Naming a project **auto-enables disk persistence** (the snapshot file defaults to `<projectdir>/state.json` unless `-state` is passed). The shared `plugins/` directory stays at `~/.cloudmock/plugins/`, so it is never tied to a project or removed by a wipe. `sanitizeProjectName()` reduces the name to a single safe path segment (no `../` traversal).

## Admin API
- `GET /api/local-data` — reports the project name, data dir, state file, and whether disk persistence is active.
- `POST /api/local-data/delete` — wipes the **current project's** on-disk data: resets in-memory service state, clears admin dashboards/views/deploys, removes the state file (+ `.tmp`) and the managed data subdirs (recreating them empty so the running stores keep working), and **never touches `plugins/`**. Other named projects on disk are untouched.

Registered in both `New()` and `NewWithDataPlane()`; `SetLocalData()` wires the footprint from the gateway at startup.

## Devtools UI
New **"Local Data"** tab in Settings showing the project / data dir / persistence status, with a **"Delete all local data"** button guarded by a confirmation modal that names the project. New `api.ts` client fns (`getLocalDataInfo`, `deleteLocalData`).

## Verification
- `go build` / `vet` / `test` for `pkg/admin` (5 handler tests) and `cmd/gateway` (sanitize/traversal test).
- devtools `tsc` typecheck + `vite build` (frontend is not CI-covered).
- **End-to-end**: ran `gateway --project cmtest`, confirmed `GET /api/local-data` reports the project dir + `persistent:true`, periodic save wrote `state.json` under the project dir, and `POST /api/local-data/delete` removed the state file + managed subdirs against the real filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)