### PR TITLE
test: restore 4 stale skipped tests (deadlocks fixed, SQS JSON added)

### DIFF
--- a/services/eks/service_test.go
+++ b/services/eks/service_test.go
@@ -167,9 +167,28 @@ func TestEKS_DeleteCluster_NotFound(t *testing.T) {
 }
 
 func TestEKS_UpdateClusterConfig(t *testing.T) {
-	// SKIP: UpdateClusterConfig calls ForceState while holding store mutex,
-	// causing a deadlock when the lifecycle callback tries to re-acquire it.
-	t.Skip("skipping due to pre-existing deadlock in store.UpdateClusterConfig + lifecycle.ForceState")
+	// Regression: UpdateClusterConfig used to call ForceState while holding the
+	// store mutex, deadlocking when the lifecycle callback re-acquired it. The
+	// store now releases s.mu before ForceState (store.go), so this exercises
+	// the full update path and must complete without deadlocking.
+	h := newEKSGateway(t)
+	createCluster(t, h, "upd-cluster")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, eksReq(t, http.MethodPost, "/clusters/upd-cluster/update-config", map[string]any{
+		"version": "1.30",
+		"resourcesVpcConfig": map[string]any{
+			"subnetIds":        []string{"subnet-9", "subnet-10"},
+			"securityGroupIds": []string{"sg-1"},
+		},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, eksBody(t, w))
+
+	m := eksJSON(t, w)
+	update := m["update"].(map[string]any)
+	assert.Equal(t, "ConfigUpdate", update["type"])
+	cluster := m["cluster"].(map[string]any)
+	assert.Equal(t, "UPDATING", cluster["status"])
 }
 
 // ---- Nodegroup ----

--- a/services/elasticache/service_test.go
+++ b/services/elasticache/service_test.go
@@ -161,9 +161,31 @@ func TestEC_DescribeCacheClusters_NotFound(t *testing.T) {
 }
 
 func TestEC_ModifyCacheCluster(t *testing.T) {
-	// SKIP: ModifyCacheCluster calls ForceState while holding store mutex,
-	// causing a deadlock when the lifecycle callback tries to re-acquire it.
-	t.Skip("skipping due to pre-existing deadlock in store.ModifyCacheCluster + lifecycle.ForceState")
+	// Regression: ModifyCacheCluster used to call ForceState while holding the
+	// store mutex, deadlocking when the lifecycle callback re-acquired it. The
+	// store now unlocks before ForceState, so this must complete and report the
+	// modified node type with a "modifying" status.
+	h := newECGateway(t)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, ecReq(t, map[string]string{
+		"Action":         "CreateCacheCluster",
+		"CacheClusterId": "mod-cluster",
+		"Engine":         "redis",
+		"CacheNodeType":  "cache.t3.micro",
+		"NumCacheNodes":  "1",
+	}))
+	require.Equal(t, http.StatusOK, w.Code, ecBody(t, w))
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, ecReq(t, map[string]string{
+		"Action":         "ModifyCacheCluster",
+		"CacheClusterId": "mod-cluster",
+		"CacheNodeType":  "cache.t3.large",
+	}))
+	require.Equal(t, http.StatusOK, w.Code, ecBody(t, w))
+	body := ecBody(t, w)
+	assert.Contains(t, body, "cache.t3.large")
+	assert.Contains(t, body, "modifying")
 }
 
 func TestEC_ModifyCacheCluster_NotFound(t *testing.T) {
@@ -278,8 +300,29 @@ func TestEC_DescribeReplicationGroups_NotFound(t *testing.T) {
 }
 
 func TestEC_ModifyReplicationGroup(t *testing.T) {
-	// SKIP: Same deadlock as ModifyCacheCluster - ForceState called under store mutex.
-	t.Skip("skipping due to pre-existing deadlock in store.ModifyReplicationGroup + lifecycle.ForceState")
+	// Regression: ModifyReplicationGroup used to call ForceState while holding
+	// the store mutex (deadlock). The store now unlocks before ForceState.
+	h := newECGateway(t)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, ecReq(t, map[string]string{
+		"Action":                      "CreateReplicationGroup",
+		"ReplicationGroupId":          "mod-rg",
+		"ReplicationGroupDescription": "before",
+		"CacheNodeType":               "cache.t3.micro",
+		"NumCacheClusters":            "2",
+	}))
+	require.Equal(t, http.StatusOK, w.Code, ecBody(t, w))
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, ecReq(t, map[string]string{
+		"Action":             "ModifyReplicationGroup",
+		"ReplicationGroupId": "mod-rg",
+		"CacheNodeType":      "cache.t3.large",
+	}))
+	require.Equal(t, http.StatusOK, w.Code, ecBody(t, w))
+	body := ecBody(t, w)
+	assert.Contains(t, body, "mod-rg")
+	assert.Contains(t, body, "modifying")
 }
 
 func TestEC_DeleteReplicationGroup(t *testing.T) {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -97,7 +97,8 @@ func TestSmoke_S3_BucketAndObjectCRUD(t *testing.T) {
 }
 
 func TestSmoke_SQS_SendReceive(t *testing.T) {
-	t.Skip("AWS SDK v2 SQS uses JSON protocol; cloudmock SQS returns XML. TODO: add JSON support to SQS service.")
+	// SQS now speaks the AWS SDK v2 JSON protocol (X-Amz-Target dispatch in
+	// services/sqs/json_handlers.go), so this end-to-end flow works.
 	cfg := cloudmockConfig(t)
 	client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
 		o.BaseEndpoint = aws.String(endpoint)


### PR DESCRIPTION
From the repo audit: four tests had been reduced to bare `t.Skip()` stubs for conditions that no longer hold.

**Deadlock-skipped (store now unlocks before `lifecycle.ForceState`):**
- `services/eks` `TestEKS_UpdateClusterConfig`
- `services/elasticache` `TestEC_ModifyCacheCluster`
- `services/elasticache` `TestEC_ModifyReplicationGroup`

Restored with real bodies that drive the update/modify paths and assert the modified field + `UPDATING`/`modifying` status. **Verified under `go test -race -timeout 90s`** — a deadlock would hang to the timeout; instead all pass in <1.5s.

**Stale premise (SQS JSON now supported):**
- `tests/smoke` `TestSmoke_SQS_SendReceive` — the skip claimed "cloudmock SQS returns XML", but SQS now speaks the AWS SDK v2 JSON protocol (`X-Amz-Target` dispatch in `services/sqs/json_handlers.go`, covered by `json_test.go`). Skip removed; smoke package still compiles under `-tags smoke` (it's excluded from default CI and needs a live server).

No production code changed — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)