### PR TITLE
feat(dynamodb): implement PartiQL ExecuteStatement (INSERT/SELECT)

### DIFF
--- a/services/dynamodb/backfill_handlers.go
+++ b/services/dynamodb/backfill_handlers.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,10 +14,17 @@ import (
 
 // ── PartiQL: ExecuteStatement ────────────────────────────────────────────────
 
-// ExecuteStatement provides basic PartiQL support. It parses INSERT and SELECT
-// statements and delegates to the existing PutItem/Query handlers.
-// Full PartiQL parsing is not implemented — this covers the most common patterns
-// that LocalStack fails on.
+// ExecuteStatement provides minimal PartiQL support for the two common forms:
+//
+//	INSERT INTO "table" VALUE {'attr': value, ...}
+//	SELECT * FROM "table" [WHERE attr = value [AND attr = value ...]]
+//
+// Values are string ('x'), number (42), boolean (true/false), null, or the ?
+// placeholder bound positionally to Parameters (typed AttributeValues). INSERT
+// delegates to PutItem; SELECT scans the table and filters by the equality
+// conditions, returning the matching Items. Anything else (UPDATE/DELETE or an
+// unparseable statement) is rejected with ValidationException rather than
+// silently returning an empty result.
 func handleExecuteStatement(ctx *service.RequestContext, store *TableStore) (*service.Response, error) {
 	var req struct {
 		Statement  string `json:"Statement"`
@@ -24,15 +33,219 @@ func handleExecuteStatement(ctx *service.RequestContext, store *TableStore) (*se
 	if err := json.Unmarshal(ctx.Body, &req); err != nil {
 		return ddbErr("ValidationException", "Invalid request body.")
 	}
-	if req.Statement == "" {
+	stmt := strings.TrimSpace(req.Statement)
+	if stmt == "" {
 		return ddbErr("ValidationException", "Statement is required.")
 	}
 
-	// Basic PartiQL stub — accepts INSERT and SELECT, delegates to store
-	// A real implementation would parse the SQL-like syntax
-	return ddbOK(map[string]any{
-		"Items": []any{},
-	})
+	switch strings.ToUpper(strings.Fields(stmt)[0]) {
+	case "INSERT":
+		return execPartiQLInsert(store, stmt, req.Parameters)
+	case "SELECT":
+		return execPartiQLSelect(store, stmt, req.Parameters)
+	default:
+		return ddbErr("ValidationException",
+			"Unsupported PartiQL statement; CloudMock supports INSERT and SELECT.")
+	}
+}
+
+// execPartiQLInsert handles: INSERT INTO "table" VALUE {'k': v, ...}
+func execPartiQLInsert(store *TableStore, stmt string, params []any) (*service.Response, error) {
+	table, ok := partiqlTableName(stmt, "INTO")
+	if !ok {
+		return ddbErr("ValidationException", `INSERT must be of the form: INSERT INTO "table" VALUE {...}`)
+	}
+	open := strings.Index(stmt, "{")
+	closeIdx := strings.LastIndex(stmt, "}")
+	if open == -1 || closeIdx == -1 || closeIdx < open {
+		return ddbErr("ValidationException", "INSERT requires a VALUE { ... } map.")
+	}
+	idx := 0
+	item, perr := parsePartiQLMap(stmt[open+1:closeIdx], params, &idx)
+	if perr != "" {
+		return ddbErr("ValidationException", perr)
+	}
+	if len(item) == 0 {
+		return ddbErr("ValidationException", "INSERT VALUE map is empty.")
+	}
+	if awsErr := store.PutItem(table, item); awsErr != nil {
+		return jsonErr(awsErr)
+	}
+	// AWS returns no Items for a successful INSERT.
+	return ddbOK(map[string]any{})
+}
+
+// execPartiQLSelect handles: SELECT * FROM "table" [WHERE attr = v [AND ...]]
+func execPartiQLSelect(store *TableStore, stmt string, params []any) (*service.Response, error) {
+	table, ok := partiqlTableName(stmt, "FROM")
+	if !ok {
+		return ddbErr("ValidationException", `SELECT must be of the form: SELECT ... FROM "table" [WHERE ...]`)
+	}
+	conds, perr := parsePartiQLWhere(stmt, params)
+	if perr != "" {
+		return ddbErr("ValidationException", perr)
+	}
+	all, _, _, awsErr := store.Scan(table, "", "", nil, nil, 0)
+	if awsErr != nil {
+		return jsonErr(awsErr)
+	}
+	items := make([]Item, 0, len(all))
+	for _, it := range all {
+		match := true
+		for _, c := range conds {
+			if !avEqual(it[c.attr], c.val) {
+				match = false
+				break
+			}
+		}
+		if match {
+			items = append(items, it)
+		}
+	}
+	return ddbOK(map[string]any{"Items": items})
+}
+
+type partiqlCond struct {
+	attr string
+	val  AttributeValue
+}
+
+// partiqlTableName returns the double-quoted table name that follows the given
+// keyword (INTO or FROM), case-insensitively.
+func partiqlTableName(stmt, keyword string) (string, bool) {
+	up := strings.ToUpper(stmt)
+	ki := strings.Index(up, keyword)
+	if ki == -1 {
+		return "", false
+	}
+	rest := stmt[ki+len(keyword):]
+	q1 := strings.Index(rest, `"`)
+	if q1 == -1 {
+		return "", false
+	}
+	rest = rest[q1+1:]
+	q2 := strings.Index(rest, `"`)
+	if q2 == -1 {
+		return "", false
+	}
+	name := rest[:q2]
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+// parsePartiQLWhere parses the optional WHERE clause into equality conditions.
+// No WHERE clause means "match everything" (full scan).
+func parsePartiQLWhere(stmt string, params []any) ([]partiqlCond, string) {
+	up := strings.ToUpper(stmt)
+	wi := strings.Index(up, " WHERE ")
+	if wi == -1 {
+		return nil, ""
+	}
+	clause := strings.TrimSpace(stmt[wi+len(" WHERE "):])
+	idx := 0
+	var conds []partiqlCond
+	for _, part := range splitPartiQL(clause, " AND ") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		eq := strings.Index(part, "=")
+		if eq == -1 {
+			return nil, "WHERE supports only '=' equality conditions: " + part
+		}
+		attr := strings.Trim(strings.TrimSpace(part[:eq]), `"'`)
+		if attr == "" {
+			return nil, "empty attribute name in WHERE"
+		}
+		av, perr := parsePartiQLValue(strings.TrimSpace(part[eq+1:]), params, &idx)
+		if perr != "" {
+			return nil, perr
+		}
+		conds = append(conds, partiqlCond{attr: attr, val: av})
+	}
+	return conds, ""
+}
+
+// parsePartiQLMap parses the body of a VALUE {...} map into an Item.
+func parsePartiQLMap(body string, params []any, idx *int) (Item, string) {
+	item := Item{}
+	for _, pair := range splitPartiQL(body, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		ci := strings.Index(pair, ":")
+		if ci == -1 {
+			return nil, "malformed VALUE entry: " + pair
+		}
+		key := strings.Trim(strings.TrimSpace(pair[:ci]), `"'`)
+		if key == "" {
+			return nil, "empty attribute name in VALUE"
+		}
+		av, perr := parsePartiQLValue(strings.TrimSpace(pair[ci+1:]), params, idx)
+		if perr != "" {
+			return nil, perr
+		}
+		item[key] = av
+	}
+	return item, ""
+}
+
+// parsePartiQLValue converts a single PartiQL literal (or ? placeholder) to a
+// typed AttributeValue. idx tracks positional Parameter consumption.
+func parsePartiQLValue(tok string, params []any, idx *int) (AttributeValue, string) {
+	switch {
+	case tok == "?":
+		if *idx >= len(params) {
+			return nil, "not enough Parameters for ? placeholders"
+		}
+		m, ok := params[*idx].(map[string]any)
+		*idx++
+		if !ok {
+			return nil, "Parameter must be a typed AttributeValue (e.g. {\"S\":\"x\"})"
+		}
+		return AttributeValue(m), ""
+	case len(tok) >= 2 && tok[0] == '\'' && tok[len(tok)-1] == '\'':
+		return AttributeValue{"S": tok[1 : len(tok)-1]}, ""
+	case strings.EqualFold(tok, "true"), strings.EqualFold(tok, "false"):
+		return AttributeValue{"BOOL": strings.EqualFold(tok, "true")}, ""
+	case strings.EqualFold(tok, "null"):
+		return AttributeValue{"NULL": true}, ""
+	default:
+		if _, err := strconv.ParseFloat(tok, 64); err == nil {
+			return AttributeValue{"N": tok}, ""
+		}
+		return nil, "unrecognized value: " + tok
+	}
+}
+
+// splitPartiQL splits s on sep, ignoring occurrences inside single-quoted
+// string literals so values like 'a,b' or 'x AND y' aren't split mid-string.
+// sep is matched case-insensitively.
+func splitPartiQL(s, sep string) []string {
+	var parts []string
+	var b strings.Builder
+	inQuote := false
+	for i := 0; i < len(s); {
+		if s[i] == '\'' {
+			inQuote = !inQuote
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		if !inQuote && i+len(sep) <= len(s) && strings.EqualFold(s[i:i+len(sep)], sep) {
+			parts = append(parts, b.String())
+			b.Reset()
+			i += len(sep)
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	parts = append(parts, b.String())
+	return parts
 }
 
 // ── Backups ──────────────────────────────────────────────────────────────────

--- a/services/dynamodb/backfill_test.go
+++ b/services/dynamodb/backfill_test.go
@@ -1,6 +1,7 @@
 package dynamodb_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,7 +33,7 @@ func TestDDB_ExecuteStatement_Insert(t *testing.T) {
 		t.Fatalf("ExecuteStatement INSERT: %d %s", w.Code, w.Body.String())
 	}
 
-	// SELECT via PartiQL
+	// SELECT via PartiQL — must return the item we just inserted.
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, ddbReq(t, "ExecuteStatement", map[string]any{
 		"Statement": `SELECT * FROM "partiql-test" WHERE pk = 'user-1'`,
@@ -40,6 +41,97 @@ func TestDDB_ExecuteStatement_Insert(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("ExecuteStatement SELECT: %d %s", w.Code, w.Body.String())
 	}
+	items := executeStatementItems(t, w)
+	if len(items) != 1 {
+		t.Fatalf("SELECT returned %d items, want 1: %s", len(items), w.Body.String())
+	}
+	if got := attrS(items[0], "pk"); got != "user-1" {
+		t.Errorf("pk = %q, want user-1", got)
+	}
+	if got := attrS(items[0], "name"); got != "Alice" {
+		t.Errorf("name = %q, want Alice", got)
+	}
+
+	// SELECT with a non-matching condition returns no items.
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, ddbReq(t, "ExecuteStatement", map[string]any{
+		"Statement": `SELECT * FROM "partiql-test" WHERE pk = 'nobody'`,
+	}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ExecuteStatement SELECT(no match): %d %s", w.Code, w.Body.String())
+	}
+	if items := executeStatementItems(t, w); len(items) != 0 {
+		t.Errorf("non-matching SELECT returned %d items, want 0", len(items))
+	}
+}
+
+func TestDDB_ExecuteStatement_Parameters(t *testing.T) {
+	handler := newDDBGateway(t)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, ddbReq(t, "CreateTable", map[string]any{
+		"TableName":            "pq-params",
+		"KeySchema":            []map[string]string{{"AttributeName": "pk", "KeyType": "HASH"}},
+		"AttributeDefinitions": []map[string]string{{"AttributeName": "pk", "AttributeType": "S"}},
+		"BillingMode":          "PAY_PER_REQUEST",
+	}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateTable: %d %s", w.Code, w.Body.String())
+	}
+
+	// INSERT using a ? placeholder bound to a typed Parameter.
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, ddbReq(t, "ExecuteStatement", map[string]any{
+		"Statement":  `INSERT INTO "pq-params" VALUE {'pk': ?}`,
+		"Parameters": []any{map[string]any{"S": "p-1"}},
+	}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ExecuteStatement INSERT(param): %d %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, ddbReq(t, "ExecuteStatement", map[string]any{
+		"Statement":  `SELECT * FROM "pq-params" WHERE pk = ?`,
+		"Parameters": []any{map[string]any{"S": "p-1"}},
+	}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ExecuteStatement SELECT(param): %d %s", w.Code, w.Body.String())
+	}
+	if items := executeStatementItems(t, w); len(items) != 1 || attrS(items[0], "pk") != "p-1" {
+		t.Errorf("parameterized SELECT mismatch: %s", w.Body.String())
+	}
+}
+
+func TestDDB_ExecuteStatement_Unsupported(t *testing.T) {
+	handler := newDDBGateway(t)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, ddbReq(t, "ExecuteStatement", map[string]any{
+		"Statement": `UPDATE "x" SET a = 1 WHERE pk = 'y'`,
+	}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unsupported statement: status %d, want 400; %s", w.Code, w.Body.String())
+	}
+}
+
+// executeStatementItems parses the Items array from an ExecuteStatement response.
+func executeStatementItems(t *testing.T, w *httptest.ResponseRecorder) []map[string]any {
+	t.Helper()
+	var resp struct {
+		Items []map[string]any `json:"Items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse ExecuteStatement response: %v (%s)", err, w.Body.String())
+	}
+	return resp.Items
+}
+
+// attrS returns the string ("S") value of an attribute in a typed item.
+func attrS(item map[string]any, attr string) string {
+	av, ok := item[attr].(map[string]any)
+	if !ok {
+		return ""
+	}
+	s, _ := av["S"].(string)
+	return s
 }
 
 // ---- Backups ----


### PR DESCRIPTION
`handleExecuteStatement` was a **stub** that always returned `{"Items": []}` while its doc comment claimed INSERT/SELECT support — silently misleading SDK callers (flagged by the repo audit as the highest-value core item).

## Implementation
Minimal but real PartiQL for the two common forms:
```
INSERT INTO "table" VALUE {'attr': value, ...}
SELECT * FROM "table" [WHERE attr = value [AND attr = value ...]]
```
- Values: strings (`'x'`), numbers, `true`/`false`, `null`, or `?` placeholders bound positionally to the typed `Parameters` list.
- INSERT → `store.PutItem`; SELECT → scan + filter by equality conditions (reusing in-package `avEqual`), returning matching `Items`.
- Quote-aware splitter so commas/`AND` inside `'...'` don't mis-split.
- **Unsupported/unparseable** statements now return `ValidationException` (400) instead of a misleading empty result.

## Tests
- INSERT→SELECT roundtrip **asserts the inserted item is returned** (pk/name), non-matching SELECT returns 0 items.
- Parameterized `?` INSERT + SELECT.
- `UPDATE` rejected with 400.

Full `services/dynamodb` suite passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)