### PR TITLE
fix(iam): evaluate attached managed policies via the IAM engine

### DIFF
--- a/services/iam/store.go
+++ b/services/iam/store.go
@@ -3,6 +3,7 @@ package iam
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -1036,13 +1037,67 @@ type AttachedPolicy struct {
 	PolicyArn  string
 }
 
-// registerPolicyWithEngine parses a JSON policy document and registers it with the IAM engine.
+// registerPolicyWithEngine parses a JSON policy document and registers it with
+// the IAM engine so policies attached via AttachUserPolicy/AttachRolePolicy are
+// actually evaluated. Best-effort: malformed documents are ignored.
 func (s *Store) registerPolicyWithEngine(principal, document string) {
-	// Best-effort: parse the policy doc and add to engine
-	// The engine uses pkg/iam.Policy type, not the managed policy wrapper
-	// For simplicity, we don't parse JSON here — the engine integration
-	// happens when callers use the pkg/iam store directly.
-	// This is a placeholder for future enhancement.
+	if s.engine == nil || document == "" {
+		return
+	}
+	if policy, ok := parsePolicyDocument(document); ok {
+		s.engine.AddPolicy(principal, policy)
+	}
+}
+
+// flexStrings unmarshals an IAM Action/Resource field, which AWS allows to be
+// either a single string or an array of strings.
+type flexStrings []string
+
+func (f *flexStrings) UnmarshalJSON(data []byte) error {
+	var one string
+	if err := json.Unmarshal(data, &one); err == nil {
+		*f = flexStrings{one}
+		return nil
+	}
+	var many []string
+	if err := json.Unmarshal(data, &many); err != nil {
+		return err
+	}
+	*f = many
+	return nil
+}
+
+// parsePolicyDocument parses an IAM policy JSON document into an iampkg.Policy,
+// tolerating the AWS convention where Action/Resource may be a string or array.
+// Returns ok=false for documents that don't parse or carry no statements.
+func parsePolicyDocument(document string) (*iampkg.Policy, bool) {
+	var doc struct {
+		Version   string `json:"Version"`
+		Statement []struct {
+			SID       string                       `json:"Sid"`
+			Effect    string                       `json:"Effect"`
+			Action    flexStrings                  `json:"Action"`
+			Resource  flexStrings                  `json:"Resource"`
+			Condition map[string]map[string]string `json:"Condition"`
+		} `json:"Statement"`
+	}
+	if err := json.Unmarshal([]byte(document), &doc); err != nil {
+		return nil, false
+	}
+	if len(doc.Statement) == 0 {
+		return nil, false
+	}
+	policy := &iampkg.Policy{Version: doc.Version}
+	for _, st := range doc.Statement {
+		policy.Statements = append(policy.Statements, iampkg.Statement{
+			SID:        st.SID,
+			Effect:     st.Effect,
+			Actions:    st.Action,
+			Resources:  st.Resource,
+			Conditions: st.Condition,
+		})
+	}
+	return policy, true
 }
 
 func generateID(prefix string, hexLen int) string {

--- a/services/iam/store_engine_test.go
+++ b/services/iam/store_engine_test.go
@@ -1,0 +1,71 @@
+package iam_test
+
+import (
+	"testing"
+
+	iampkg "github.com/Viridian-Inc/cloudmock/pkg/iam"
+	iamsvc "github.com/Viridian-Inc/cloudmock/services/iam"
+)
+
+// Attaching a managed policy must register it with the IAM engine so the
+// engine actually evaluates it (registerPolicyWithEngine was previously a
+// no-op, so attached policies were silently ignored).
+func TestStore_AttachUserPolicy_RegistersWithEngine(t *testing.T) {
+	const account = "000000000000"
+	engine := iampkg.NewEngine()
+	store := iamsvc.NewStore(account, engine, iampkg.NewStore(account))
+
+	if _, err := store.CreateUser("alice"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	// Single-string Action/Resource (the common AWS form the parser must tolerate).
+	pol, err := store.CreatePolicy("AllowS3Get",
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`, "")
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	if err := store.AttachUserPolicy("alice", pol.Arn); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	principal := "arn:aws:iam::" + account + ":user/alice"
+
+	if res := engine.Evaluate(&iampkg.EvalRequest{
+		Principal: principal, Action: "s3:GetObject", Resource: "arn:aws:s3:::bucket/key",
+	}); res.Decision != iampkg.Allow {
+		t.Fatalf("allowed action: decision = %v, want Allow (reason=%s)", res.Decision, res.Reason)
+	}
+
+	if res := engine.Evaluate(&iampkg.EvalRequest{
+		Principal: principal, Action: "dynamodb:PutItem", Resource: "*",
+	}); res.Decision != iampkg.Deny {
+		t.Errorf("unrelated action: decision = %v, want implicit Deny", res.Decision)
+	}
+}
+
+func TestParsePolicyDocument_Tolerant(t *testing.T) {
+	// Array-form Action plus an explicit Deny — both must register.
+	const account = "000000000000"
+	engine := iampkg.NewEngine()
+	store := iamsvc.NewStore(account, engine, iampkg.NewStore(account))
+
+	if _, err := store.CreateUser("bob"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	pol, err := store.CreatePolicy("Mixed",
+		`{"Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:PutObject"],"Resource":["*"]},{"Effect":"Deny","Action":"s3:DeleteObject","Resource":"*"}]}`, "")
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	if err := store.AttachUserPolicy("bob", pol.Arn); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+	principal := "arn:aws:iam::" + account + ":user/bob"
+
+	if res := engine.Evaluate(&iampkg.EvalRequest{Principal: principal, Action: "s3:PutObject", Resource: "*"}); res.Decision != iampkg.Allow {
+		t.Errorf("array action s3:PutObject: decision = %v, want Allow", res.Decision)
+	}
+	if res := engine.Evaluate(&iampkg.EvalRequest{Principal: principal, Action: "s3:DeleteObject", Resource: "*"}); res.Decision != iampkg.Deny {
+		t.Errorf("explicit deny s3:DeleteObject: decision = %v, want Deny", res.Decision)
+	}
+}


### PR DESCRIPTION
`registerPolicyWithEngine` was a **no-op placeholder**, so policies attached via `AttachUserPolicy`/`AttachRolePolicy` were never registered with the IAM engine — and therefore never evaluated (flagged by the repo audit).

## Fix
Parse the attached policy document and call `engine.AddPolicy(principal, policy)`. A tolerant parser (`flexStrings`) accepts the AWS convention where a statement's `Action`/`Resource` may be a **single string or an array** (the engine's plain `[]string` fields can't unmarshal a bare string directly). Malformed documents are ignored (best-effort) — matching the existing call sites that already guard on `engine != nil` and a non-empty `Document`.

## Tests
- Attach a managed policy → `engine.Evaluate` returns **Allow** for the granted action and **implicit Deny** for an unrelated one.
- Array-form `Action` + an explicit `Deny` statement both register and evaluate correctly.

`go vet` clean; `services/iam` + `pkg/iam` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)