### PR TITLE
fix(sdk): stop the DynamoDB TTL reaper on CloudMock.Close()

### DIFF
--- a/sdk/close_test.go
+++ b/sdk/close_test.go
@@ -1,0 +1,11 @@
+package sdk
+
+import "testing"
+
+// Close must tear down background work (the DynamoDB TTL reaper) and be safe to
+// call more than once.
+func TestCloudMock_Close_Idempotent(t *testing.T) {
+	cm := New()
+	cm.Close()
+	cm.Close()
+}

--- a/sdk/cloudmock.go
+++ b/sdk/cloudmock.go
@@ -63,6 +63,7 @@ type CloudMock struct {
 	cfg          aws.Config
 	chaosEngine  *gateway.ChaosEngine
 	traceStore   *gateway.TraceStore
+	closers      []func() // teardown hooks run by Close (e.g. stop background goroutines)
 }
 
 // New creates a new in-process CloudMock instance. By default it uses a
@@ -96,7 +97,8 @@ func New(opts ...Option) *CloudMock {
 	// Register core services — these cover the vast majority of test use cases.
 	registry.Register(s3svc.NewWithBus(bus))
 	registry.Register(stssvc.New(c.AccountID))
-	registry.Register(dynamodbsvc.New(c.AccountID, c.Region))
+	ddb := dynamodbsvc.New(c.AccountID, c.Region)
+	registry.Register(ddb)
 	registry.Register(sqssvc.New(c.AccountID, c.Region))
 
 	// Build the gateway handler.
@@ -151,6 +153,7 @@ func New(opts ...Option) *CloudMock {
 		cfg:         awsConfig,
 		chaosEngine: chaosEngine,
 		traceStore:  traceStore,
+		closers:     []func(){ddb.Close},
 	}
 }
 
@@ -164,7 +167,11 @@ func (cm *CloudMock) TraceStore() *gateway.TraceStore {
 	return cm.traceStore
 }
 
-// Close releases resources held by this CloudMock instance.
+// Close releases resources held by this CloudMock instance, including stopping
+// background goroutines such as the DynamoDB TTL reaper. Safe to call multiple
+// times; the underlying service closers are idempotent.
 func (cm *CloudMock) Close() {
-	// Currently a no-op — reserved for future cleanup (DynamoDB TTL reapers, etc.)
+	for _, c := range cm.closers {
+		c()
+	}
 }

--- a/services/dynamodb/service.go
+++ b/services/dynamodb/service.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/Viridian-Inc/cloudmock/pkg/rustddb"
 	"github.com/Viridian-Inc/cloudmock/pkg/schema"
@@ -14,6 +15,18 @@ type DynamoDBService struct {
 	store     *TableStore
 	rustStore *rustddb.Store // nil unless CLOUDMOCK_RUST_DDB=true
 	ttlDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// Close stops the background TTL reaper goroutine started in New. It is safe to
+// call multiple times. Long-lived servers never need this, but in-process
+// embeddings (e.g. the SDK) call it on teardown to avoid leaking the goroutine.
+func (s *DynamoDBService) Close() {
+	s.closeOnce.Do(func() {
+		if s.ttlDone != nil {
+			close(s.ttlDone)
+		}
+	})
 }
 
 // New returns a new DynamoDBService for the given AWS account ID and region.

--- a/services/dynamodb/service_close_test.go
+++ b/services/dynamodb/service_close_test.go
@@ -1,0 +1,19 @@
+package dynamodb
+
+import "testing"
+
+func TestDynamoDBService_CloseStopsReaper(t *testing.T) {
+	svc := New("000000000000", "us-east-1")
+
+	svc.Close()
+	// ttlDone must be closed so the reaper goroutine's <-done case fires and it
+	// returns (a receive on a closed channel proceeds immediately).
+	select {
+	case <-svc.ttlDone:
+	default:
+		t.Fatal("ttlDone not closed after Close()")
+	}
+
+	// Idempotent: a second Close must not panic (close() of a closed channel does).
+	svc.Close()
+}


### PR DESCRIPTION
`CloudMock.Close()` was a no-op, so the DynamoDB TTL reaper goroutine started in `dynamodbsvc.New()` **leaked** for every in-process `CloudMock` created and discarded (repo audit).

## Fix
- Add an **idempotent** `DynamoDBService.Close()` that closes its `ttlDone` channel — the reaper's `select { case <-done: return }` then exits.
- `CloudMock` keeps a list of teardown `closers` and runs them from `Close()`, starting with the DynamoDB service. Generalizes cleanly to future services that need teardown.

## Tests
- `DynamoDBService.Close()` closes `ttlDone` and is idempotent (a double `close()` would panic).
- `CloudMock.Close()` is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)