### PR TITLE
refactor(dynamodb): remove Task-4 backward-compat shim fields

### DIFF
--- a/services/dynamodb/handlers.go
+++ b/services/dynamodb/handlers.go
@@ -375,7 +375,7 @@ func tableToDescription(t *Table, arn string) tableDescription {
 		KeySchema:            t.KeySchema,
 		AttributeDefinitions: t.AttributeDefinitions,
 		CreationDateTime:     t.CreationDateTime,
-		ItemCount:            t.ItemCount,
+		ItemCount:            t.itemCount(),
 		TableArn:             arn,
 		// Always report WarmThroughput as ACTIVE — CloudMock has no async warm-up.
 		// This prevents the Terraform AWS provider v6 waiter from timing out when
@@ -389,7 +389,10 @@ func tableToDescription(t *Table, arn string) tableDescription {
 		desc.ProvisionedThroughput = t.ProvisionedThroughput
 	}
 	for _, gsi := range t.GSIs {
-		itemCount := int64(len(t.GSIItems[gsi.IndexName]))
+		var itemCount int64
+		if st, ok := t.gsiStores[gsi.IndexName]; ok {
+			itemCount = int64(st.itemCount())
+		}
 		desc.GlobalSecondaryIndexes = append(desc.GlobalSecondaryIndexes, gsiDescription{
 			IndexName:             gsi.IndexName,
 			KeySchema:             gsi.KeySchema,
@@ -402,7 +405,10 @@ func tableToDescription(t *Table, arn string) tableDescription {
 		})
 	}
 	for _, lsi := range t.LSIs {
-		itemCount := int64(len(t.LSIItems[lsi.IndexName]))
+		var itemCount int64
+		if st, ok := t.lsiStores[lsi.IndexName]; ok {
+			itemCount = int64(st.itemCount())
+		}
 		desc.LocalSecondaryIndexes = append(desc.LocalSecondaryIndexes, lsiDescription{
 			IndexName:      lsi.IndexName,
 			KeySchema:      lsi.KeySchema,

--- a/services/dynamodb/store.go
+++ b/services/dynamodb/store.go
@@ -43,15 +43,6 @@ func (s *TableStore) CreateTable(name string, keySchema []KeySchemaElement, attr
 		billingMode = "PROVISIONED"
 	}
 
-	gsiItems := make(map[string][]Item)
-	for _, gsi := range gsis {
-		gsiItems[gsi.IndexName] = nil
-	}
-	lsiItems := make(map[string][]Item)
-	for _, lsi := range lsis {
-		lsiItems[lsi.IndexName] = nil
-	}
-
 	table := &Table{
 		Name:                  name,
 		KeySchema:             keySchema,
@@ -62,8 +53,6 @@ func (s *TableStore) CreateTable(name string, keySchema []KeySchemaElement, attr
 		ProvisionedThroughput: pt,
 		GSIs:                  gsis,
 		LSIs:                  lsis,
-		GSIItems:              gsiItems,
-		LSIItems:              lsiItems,
 	}
 
 	table.initPartitions()
@@ -284,7 +273,6 @@ func (s *TableStore) PutItem(tableName string, item Item, condExpr ...string) *s
 		table.deindexItem(old)
 	}
 	table.indexItem(item)
-	table.ItemCount = table.itemCount()
 	table.mu.Unlock()
 
 	if table.Stream != nil {
@@ -416,7 +404,6 @@ func (s *TableStore) DeleteItem(tableName string, key Item, condExpr ...string) 
 			delete(table.partitions, pkVal)
 		}
 		table.deindexItem(old)
-		table.ItemCount = table.itemCount()
 		table.mu.Unlock()
 
 		if table.Stream != nil {
@@ -431,7 +418,6 @@ func (s *TableStore) deleteFromTable(table *Table, key Item) *service.AWSError {
 	old := table.deleteItem(key)
 	if old != nil {
 		table.deindexItem(old)
-		table.ItemCount = table.itemCount() // sync compat field
 		if table.Stream != nil {
 			table.Stream.appendRecord("REMOVE", copyItem(old), nil)
 		}
@@ -478,7 +464,6 @@ func (s *TableStore) updateInTable(table *Table, key Item, updateExpr string, ex
 	// Insert/replace using partition store.
 	table.putItem(target)
 	table.indexItem(target)
-	table.ItemCount = table.itemCount() // sync compat field
 
 	if table.Stream != nil {
 		if found {
@@ -505,7 +490,6 @@ func (s *TableStore) putInTable(table *Table, item Item) {
 		table.deindexItem(old)
 	}
 	table.indexItem(item)
-	table.ItemCount = table.itemCount() // sync compat field
 
 	if table.Stream != nil {
 		if old != nil {

--- a/services/dynamodb/table.go
+++ b/services/dynamodb/table.go
@@ -73,17 +73,11 @@ type Table struct {
 	cachedHashKey  string
 	cachedRangeKey string
 
-	// --- New partition-based storage ---
+	// --- Partition-based storage (authoritative) ---
 	partitions map[string]*Partition  // pkValue → partition
 	gsiStores  map[string]*IndexStore // indexName → index store
 	lsiStores  map[string]*IndexStore // indexName → index store
 	count      atomic.Int64
-
-	// --- Backward-compat shims for store.go / handlers.go (Task 4 removes these) ---
-	Items     []Item            // Deprecated: kept for store.go compatibility
-	ItemCount int64             // Deprecated: kept for handlers.go compatibility
-	GSIItems  map[string][]Item // Deprecated: kept for handlers.go / store.go compatibility
-	LSIItems  map[string][]Item // Deprecated: kept for handlers.go / store.go compatibility
 }
 
 // initPartitions initializes the partition-based storage for a table.
@@ -178,9 +172,6 @@ func (t *Table) indexItem(item Item) {
 			store.remove(item, hk)
 			store.put(item, hk)
 		}
-		// Also maintain legacy GSIItems for backward compat.
-		t.removeFromIndex(t.GSIItems, gsi.IndexName, gsi.KeySchema, item)
-		t.GSIItems[gsi.IndexName] = append(t.GSIItems[gsi.IndexName], item)
 	}
 	for _, lsi := range t.LSIs {
 		hk := gsiHashKeyName(lsi.KeySchema)
@@ -200,8 +191,6 @@ func (t *Table) indexItem(item Item) {
 			store.remove(item, hk)
 			store.put(item, hk)
 		}
-		t.removeFromIndex(t.LSIItems, lsi.IndexName, lsi.KeySchema, item)
-		t.LSIItems[lsi.IndexName] = append(t.LSIItems[lsi.IndexName], item)
 	}
 }
 
@@ -212,31 +201,12 @@ func (t *Table) deindexItem(item Item) {
 		if store, ok := t.gsiStores[gsi.IndexName]; ok {
 			store.remove(item, hk)
 		}
-		t.removeFromIndex(t.GSIItems, gsi.IndexName, gsi.KeySchema, item)
 	}
 	for _, lsi := range t.LSIs {
 		hk := gsiHashKeyName(lsi.KeySchema)
 		if store, ok := t.lsiStores[lsi.IndexName]; ok {
 			store.remove(item, hk)
 		}
-		t.removeFromIndex(t.LSIItems, lsi.IndexName, lsi.KeySchema, item)
-	}
-}
-
-// removeFromIndex removes an item from a specific legacy index by matching key schema.
-func (t *Table) removeFromIndex(indexItems map[string][]Item, indexName string, ks []KeySchemaElement, item Item) {
-	items := indexItems[indexName]
-	hk := gsiHashKeyName(ks)
-	rk := gsiRangeKeyName(ks)
-	for i, existing := range items {
-		if !avEqual(item[hk], existing[hk]) {
-			continue
-		}
-		if rk != "" && !avEqual(item[rk], existing[rk]) {
-			continue
-		}
-		indexItems[indexName] = append(items[:i], items[i+1:]...)
-		return
 	}
 }
 


### PR DESCRIPTION
The `Table` struct carried four deprecated shim fields — `Items`, `ItemCount`, `GSIItems`, `LSIItems` — kept "until Task 4". The partition-based stores (`partitions`, `gsiStores`, `lsiStores`, `count`) are authoritative, so the shims were dead weight maintained by parallel dual-writes (repo audit).

## Changes
- `handlers.go` (`tableToDescription`): `ItemCount` → `t.itemCount()` (atomic count); GSI/LSI item counts → `gsiStores`/`lsiStores` `IndexStore.itemCount()`.
- `table.go`: drop the legacy dual-write maintenance in `indexItem`/`deindexItem` and the now-unused `removeFromIndex` helper; delete the four deprecated struct fields.
- `store.go`: remove the `GSIItems`/`LSIItems` map init in `CreateTable` and the five `table.ItemCount = table.itemCount()` sync lines.

## No behavior change
`ExportState` already serialized items from the partition store (`scanAll`), and **no test referenced the runtime shim fields** (`snapshot_test`'s `tbl.Items` is the serialized DTO, not `Table.Items`). Full `services/dynamodb` suite passes; `go vet` clean.

> Note: `go test -race` surfaces **pre-existing** data races in `DeleteItem` (`Partition.delete` vs `len`) and the TTL reaper — present on `main` too, out of scope here (CI does not run `-race`). Flagging as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)