### PR TITLE
feat(cicd): GitLab CI pipeline webhook ingestion

### DIFF
--- a/pkg/admin/api.go
+++ b/pkg/admin/api.go
@@ -3937,6 +3937,7 @@ func (a *API) SetCICDStore(s cicd.Store) {
 	a.mux.HandleFunc("/api/pipelines/", a.handlePipelineByID)
 	a.mux.HandleFunc("/api/ci/summary", a.handleCISummary)
 	a.mux.HandleFunc("/api/webhooks/github", a.handleGitHubWebhook)
+	a.mux.HandleFunc("/api/webhooks/gitlab", a.handleGitLabWebhook)
 }
 
 // SetDynamoStore configures DynamoDB-backed persistence for dashboards,

--- a/pkg/admin/cicd_handlers.go
+++ b/pkg/admin/cicd_handlers.go
@@ -197,6 +197,53 @@ func (a *API) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "processed", "pipeline_id": pipeline.ID})
 }
 
+// handleGitLabWebhook processes GitLab CI "Pipeline Hook" events, mirroring
+// handleGitHubWebhook. POST /api/webhooks/gitlab
+func (a *API) handleGitLabWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	if a.cicdStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "CI/CD store not available")
+		return
+	}
+
+	var ev cicd.GitLabPipelineEvent
+	if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	// GitLab fans out many hook kinds (push, merge_request, job, pipeline...)
+	// to the same URL; only pipeline events become deploys.
+	if ev.ObjectKind != "pipeline" {
+		writeJSON(w, http.StatusOK, map[string]string{
+			"status":      "ignored",
+			"event":       r.Header.Get("X-Gitlab-Event"),
+			"object_kind": ev.ObjectKind,
+		})
+		return
+	}
+
+	pipeline := cicd.ParseGitLabPipeline(ev)
+	if err := a.cicdStore.SavePipeline(pipeline); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if pipeline.Status == "success" {
+		a.createDeployFromPipeline(r, pipeline)
+	}
+
+	a.auditLog(r.Context(), "gitlab.webhook.processed", "pipeline:"+pipeline.ID, map[string]any{
+		"repo":   pipeline.Repo,
+		"status": pipeline.Status,
+	})
+	writeJSON(w, http.StatusOK, map[string]string{"status": "processed", "pipeline_id": pipeline.ID})
+}
+
 // createDeployFromPipeline creates a deploy event when a pipeline succeeds.
 func (a *API) createDeployFromPipeline(r *http.Request, p cicd.Pipeline) {
 	if a.dp != nil {

--- a/pkg/cicd/gitlab_webhook.go
+++ b/pkg/cicd/gitlab_webhook.go
@@ -1,0 +1,117 @@
+package cicd
+
+import (
+	"fmt"
+	"time"
+)
+
+// GitLabPipelineEvent represents the relevant fields from a GitLab CI
+// "Pipeline Hook" webhook payload (object_kind: "pipeline").
+type GitLabPipelineEvent struct {
+	ObjectKind       string `json:"object_kind"` // "pipeline"
+	ObjectAttributes struct {
+		ID         int64  `json:"id"`
+		Ref        string `json:"ref"`
+		SHA        string `json:"sha"`
+		Status     string `json:"status"`   // success, failed, running, pending, canceled, skipped...
+		Duration   int64  `json:"duration"` // seconds
+		CreatedAt  string `json:"created_at"`
+		FinishedAt string `json:"finished_at"`
+		URL        string `json:"url"`
+	} `json:"object_attributes"`
+	Project struct {
+		PathWithNamespace string `json:"path_with_namespace"`
+		WebURL            string `json:"web_url"`
+	} `json:"project"`
+	User struct {
+		Name string `json:"name"`
+	} `json:"user"`
+	Builds []struct {
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		StartedAt  string `json:"started_at"`
+		FinishedAt string `json:"finished_at"`
+	} `json:"builds"`
+}
+
+// ParseGitLabPipeline converts a GitLab Pipeline Hook payload into our Pipeline
+// type, mirroring ParseGitHubWorkflowRun.
+func ParseGitLabPipeline(ev GitLabPipelineEvent) Pipeline {
+	attrs := ev.ObjectAttributes
+
+	var finishedAt *time.Time
+	if t := parseGitLabTime(attrs.FinishedAt); !t.IsZero() {
+		finishedAt = &t
+	}
+
+	var jobs []Job
+	for _, b := range ev.Builds {
+		job := Job{
+			Name:      b.Name,
+			Status:    mapGitLabStatus(b.Status),
+			StartedAt: parseGitLabTime(b.StartedAt),
+		}
+		if ft := parseGitLabTime(b.FinishedAt); !ft.IsZero() {
+			job.FinishedAt = &ft
+			if !job.StartedAt.IsZero() {
+				job.DurationMs = ft.Sub(job.StartedAt).Milliseconds()
+			}
+		}
+		jobs = append(jobs, job)
+	}
+
+	url := attrs.URL
+	if url == "" {
+		url = ev.Project.WebURL
+	}
+
+	return Pipeline{
+		ID:         fmt.Sprintf("gl-%d", attrs.ID),
+		Provider:   "gitlab_ci",
+		Repo:       ev.Project.PathWithNamespace,
+		Branch:     attrs.Ref,
+		CommitHash: attrs.SHA,
+		Status:     mapGitLabStatus(attrs.Status),
+		StartedAt:  parseGitLabTime(attrs.CreatedAt),
+		FinishedAt: finishedAt,
+		DurationMs: attrs.Duration * 1000, // GitLab reports seconds
+		URL:        url,
+		Jobs:       jobs,
+	}
+}
+
+// mapGitLabStatus normalizes GitLab pipeline/job statuses to our Pipeline
+// status vocabulary (running/success/failure/cancelled).
+func mapGitLabStatus(status string) string {
+	switch status {
+	case "success":
+		return "success"
+	case "failed":
+		return "failure"
+	case "canceled", "cancelled":
+		return "cancelled"
+	case "created", "waiting_for_resource", "preparing", "pending", "running", "manual", "scheduled":
+		return "running"
+	default:
+		return status
+	}
+}
+
+// parseGitLabTime leniently parses the timestamp formats GitLab emits in
+// webhooks (which are not RFC3339), returning the zero time on failure.
+func parseGitLabTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05 -0700",
+		"2006-01-02 15:04:05 MST",
+		"2006-01-02T15:04:05.000Z",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}

--- a/pkg/cicd/gitlab_webhook_test.go
+++ b/pkg/cicd/gitlab_webhook_test.go
@@ -1,0 +1,66 @@
+package cicd
+
+import "testing"
+
+func TestParseGitLabPipeline_Success(t *testing.T) {
+	var ev GitLabPipelineEvent
+	ev.ObjectKind = "pipeline"
+	ev.ObjectAttributes.ID = 42
+	ev.ObjectAttributes.Ref = "main"
+	ev.ObjectAttributes.SHA = "abc123"
+	ev.ObjectAttributes.Status = "success"
+	ev.ObjectAttributes.Duration = 63 // seconds
+	ev.ObjectAttributes.CreatedAt = "2026-06-15 12:00:00 UTC"
+	ev.ObjectAttributes.FinishedAt = "2026-06-15 12:01:03 UTC"
+	ev.ObjectAttributes.URL = "https://gitlab.com/g/p/-/pipelines/42"
+	ev.Project.PathWithNamespace = "g/p"
+	ev.Builds = []struct {
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		StartedAt  string `json:"started_at"`
+		FinishedAt string `json:"finished_at"`
+	}{
+		{Name: "build", Status: "success", StartedAt: "2026-06-15 12:00:00 UTC", FinishedAt: "2026-06-15 12:00:30 UTC"},
+	}
+
+	p := ParseGitLabPipeline(ev)
+
+	if p.ID != "gl-42" {
+		t.Errorf("ID = %q, want gl-42", p.ID)
+	}
+	if p.Provider != "gitlab_ci" {
+		t.Errorf("Provider = %q, want gitlab_ci", p.Provider)
+	}
+	if p.Repo != "g/p" || p.Branch != "main" || p.CommitHash != "abc123" {
+		t.Errorf("repo/branch/commit = %q/%q/%q", p.Repo, p.Branch, p.CommitHash)
+	}
+	if p.Status != "success" {
+		t.Errorf("Status = %q, want success", p.Status)
+	}
+	if p.DurationMs != 63000 {
+		t.Errorf("DurationMs = %d, want 63000 (seconds→ms)", p.DurationMs)
+	}
+	if p.FinishedAt == nil {
+		t.Error("FinishedAt should be set")
+	}
+	if len(p.Jobs) != 1 || p.Jobs[0].Status != "success" || p.Jobs[0].DurationMs != 30000 {
+		t.Errorf("jobs = %+v", p.Jobs)
+	}
+}
+
+func TestMapGitLabStatus(t *testing.T) {
+	cases := map[string]string{
+		"success":  "success",
+		"failed":   "failure",
+		"canceled": "cancelled",
+		"running":  "running",
+		"pending":  "running",
+		"created":  "running",
+		"weird":    "weird", // unknown statuses pass through
+	}
+	for in, want := range cases {
+		if got := mapGitLabStatus(in); got != want {
+			t.Errorf("mapGitLabStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Mirrors the existing GitHub Actions ingestion path for **GitLab CI**, so GitLab pipelines also create deploy events (audit roadmap item, `docs/v1-feature-roadmap.md:171`).

## Changes
- **`pkg/cicd/gitlab_webhook.go`** — `GitLabPipelineEvent` + `ParseGitLabPipeline`, mapping a GitLab "Pipeline Hook" payload to the existing `cicd.Pipeline` model. `mapGitLabStatus` normalizes GitLab statuses (success/failed/canceled/running/…) to our vocabulary, and `parseGitLabTime` leniently parses GitLab's non-RFC3339 timestamps. Duration converted seconds→ms.
- **`pkg/admin/cicd_handlers.go`** — `handleGitLabWebhook` saves the pipeline and, on `success`, calls the **shared `createDeployFromPipeline`** (identical to GitHub). Non-pipeline hook kinds are ignored.
- **`pkg/admin/api.go`** — register `POST /api/webhooks/gitlab` in `SetCICDStore` alongside the github route.

## Tests
- `ParseGitLabPipeline`: id (`gl-N`), provider, repo/branch/commit, status, duration (s→ms), finished-at, jobs.
- `mapGitLabStatus` normalization (incl. unknown-status passthrough).

`go build`/`vet` clean; full `pkg/cicd` + `pkg/admin` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)