### PR TITLE
feat(notify): maintenance-window suppression + team-tier routing

### DIFF
--- a/pkg/notify/router.go
+++ b/pkg/notify/router.go
@@ -15,18 +15,23 @@ import (
 // Router matches incoming notifications against routing rules and dispatches
 // them to the appropriate channels. It is safe for concurrent use.
 type Router struct {
-	mu       sync.RWMutex
-	routes   []Route
-	channels map[string]Channel // keyed by "type:name"
-	history  []DeliveryRecord
-	maxHist  int
+	mu          sync.RWMutex
+	routes      []Route
+	channels    map[string]Channel // keyed by "type:name"
+	history     []DeliveryRecord
+	maxHist     int
+	windows     []MaintenanceWindow
+	teams       map[string]Team   // team name → team
+	serviceTeam map[string]string // service → owning team name
 }
 
 // NewRouter creates a notification router.
 func NewRouter() *Router {
 	return &Router{
-		channels: make(map[string]Channel),
-		maxHist:  500,
+		channels:    make(map[string]Channel),
+		maxHist:     500,
+		teams:       make(map[string]Team),
+		serviceTeam: make(map[string]string),
 	}
 }
 
@@ -45,45 +50,143 @@ func (r *Router) Notify(ctx context.Context, n Notification) error {
 	r.mu.RLock()
 	routes := make([]Route, len(r.routes))
 	copy(routes, r.routes)
+	windows := make([]MaintenanceWindow, len(r.windows))
+	copy(windows, r.windows)
+	team, hasTeam := r.teams[r.serviceTeam[n.Service]]
 	r.mu.RUnlock()
 
+	// Maintenance-window suppression: if an active window covers this
+	// notification, record it as suppressed and dispatch to nothing.
+	now := time.Now()
+	for _, w := range windows {
+		if w.suppresses(n, now) {
+			r.recordDelivery(n, ChannelRef{Type: "suppressed", Name: w.Name}, "window:"+w.ID,
+				"suppressed", "maintenance window active")
+			return nil
+		}
+	}
+
 	var firstErr error
+	sent := make(map[string]bool) // channel keys already dispatched (for team dedup)
 
 	for _, route := range routes {
-		if !route.Enabled {
+		if !route.Enabled || !matchesRoute(route.Match, n) {
 			continue
 		}
-		if !matchesRoute(route.Match, n) {
-			continue
-		}
-
 		for _, ref := range route.Channels {
-			ch := r.resolveChannel(ref)
-			if ch == nil {
-				slog.Warn("notify: channel not found, building on-demand",
-					"type", ref.Type, "name", ref.Name)
-				ch = r.buildChannel(ref)
-				if ch == nil {
-					r.recordDelivery(n, ref, route.ID, "failed", "channel not configured")
-					continue
-				}
-			}
+			r.dispatch(ctx, n, ref, route.ID, &firstErr)
+			sent[ref.Type+":"+ref.Name] = true
+		}
+	}
 
-			err := ch.Send(ctx, n)
-			if err != nil {
-				slog.Warn("notify: channel delivery failed",
-					"type", ref.Type, "name", ref.Name, "error", err)
-				r.recordDelivery(n, ref, route.ID, "failed", err.Error())
-				if firstErr == nil {
-					firstErr = err
-				}
-			} else {
-				r.recordDelivery(n, ref, route.ID, "success", "")
+	// Team-tier routing: also deliver to the owning team's channels that a
+	// direct route didn't already cover.
+	if hasTeam {
+		for _, ref := range team.Channels {
+			if sent[ref.Type+":"+ref.Name] {
+				continue
 			}
+			r.dispatch(ctx, n, ref, "team:"+team.Name, &firstErr)
+			sent[ref.Type+":"+ref.Name] = true
 		}
 	}
 
 	return firstErr
+}
+
+// dispatch resolves a channel ref and sends the notification, recording the
+// delivery outcome. *firstErr captures the first delivery error.
+func (r *Router) dispatch(ctx context.Context, n Notification, ref ChannelRef, routeID string, firstErr *error) {
+	ch := r.resolveChannel(ref)
+	if ch == nil {
+		slog.Warn("notify: channel not found, building on-demand", "type", ref.Type, "name", ref.Name)
+		ch = r.buildChannel(ref)
+		if ch == nil {
+			r.recordDelivery(n, ref, routeID, "failed", "channel not configured")
+			return
+		}
+	}
+	if err := ch.Send(ctx, n); err != nil {
+		slog.Warn("notify: channel delivery failed", "type", ref.Type, "name", ref.Name, "error", err)
+		r.recordDelivery(n, ref, routeID, "failed", err.Error())
+		if *firstErr == nil {
+			*firstErr = err
+		}
+		return
+	}
+	r.recordDelivery(n, ref, routeID, "success", "")
+}
+
+// --- Maintenance windows ---
+
+// AddWindow registers a maintenance window, generating an ID if empty.
+func (r *Router) AddWindow(w MaintenanceWindow) MaintenanceWindow {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if w.ID == "" {
+		w.ID = generateID()
+	}
+	r.windows = append(r.windows, w)
+	return w
+}
+
+// RemoveWindow deletes a maintenance window by ID; reports whether it existed.
+func (r *Router) RemoveWindow(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, w := range r.windows {
+		if w.ID == id {
+			r.windows = append(r.windows[:i], r.windows[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// ListWindows returns a copy of the configured maintenance windows.
+func (r *Router) ListWindows() []MaintenanceWindow {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]MaintenanceWindow, len(r.windows))
+	copy(out, r.windows)
+	return out
+}
+
+// LoadWindows replaces all maintenance windows (from config).
+func (r *Router) LoadWindows(ws []MaintenanceWindow) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.windows = make([]MaintenanceWindow, len(ws))
+	for i, w := range ws {
+		if w.ID == "" {
+			w.ID = generateID()
+		}
+		r.windows[i] = w
+	}
+}
+
+// --- Team-tier routing ---
+
+// SetTeam registers/updates a team and the services it owns. Services map to
+// the team's channels in addition to any direct service→channel routes.
+func (r *Router) SetTeam(team Team, services []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.teams[team.Name] = team
+	for _, s := range services {
+		r.serviceTeam[s] = team.Name
+	}
+}
+
+// ListTeams returns the configured teams.
+func (r *Router) ListTeams() []Team {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Team, 0, len(r.teams))
+	for _, t := range r.teams {
+		out = append(out, t)
+	}
+	return out
 }
 
 // AddRoute adds a routing rule. If the ID is empty, one is generated.

--- a/pkg/notify/routing_enhancements_test.go
+++ b/pkg/notify/routing_enhancements_test.go
@@ -1,0 +1,124 @@
+package notify
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordChannel struct {
+	typ   string
+	mu    sync.Mutex
+	sends []Notification
+}
+
+func (c *recordChannel) Type() string { return c.typ }
+func (c *recordChannel) Send(_ context.Context, n Notification) error {
+	c.mu.Lock()
+	c.sends = append(c.sends, n)
+	c.mu.Unlock()
+	return nil
+}
+func (c *recordChannel) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.sends)
+}
+
+func routerWithRoute(ch *recordChannel, name string, match RouteMatch) *Router {
+	r := NewRouter()
+	r.RegisterChannel(name, ch)
+	r.AddRoute(Route{
+		Name:     "r",
+		Match:    match,
+		Channels: []ChannelRef{{Type: ch.typ, Name: name}},
+		Enabled:  true,
+	})
+	return r
+}
+
+func TestMaintenanceWindow_Suppresses(t *testing.T) {
+	ch := &recordChannel{typ: "slack"}
+	r := routerWithRoute(ch, "ops", RouteMatch{Services: []string{"api"}})
+
+	// Active window scoped to "api" suppresses delivery.
+	now := time.Now()
+	r.AddWindow(MaintenanceWindow{
+		Name: "deploy", Start: now.Add(-time.Hour), End: now.Add(time.Hour),
+		Services: []string{"api"},
+	})
+	if err := r.Notify(context.Background(), Notification{Service: "api", Severity: "warning"}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if ch.count() != 0 {
+		t.Errorf("expected suppression (0 sends), got %d", ch.count())
+	}
+	// A "suppressed" delivery record should exist.
+	suppressed := false
+	for _, rec := range r.History(10) {
+		if rec.Status == "suppressed" {
+			suppressed = true
+		}
+	}
+	if !suppressed {
+		t.Error("expected a suppressed delivery record")
+	}
+}
+
+func TestMaintenanceWindow_OutOfScopeAndExpired(t *testing.T) {
+	ch := &recordChannel{typ: "slack"}
+	r := routerWithRoute(ch, "ops", RouteMatch{Services: []string{"api"}})
+	now := time.Now()
+
+	// Expired window must not suppress.
+	r.AddWindow(MaintenanceWindow{Name: "old", Start: now.Add(-2 * time.Hour), End: now.Add(-time.Hour)})
+	if err := r.Notify(context.Background(), Notification{Service: "api"}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if ch.count() != 1 {
+		t.Errorf("expired window should not suppress; sends = %d, want 1", ch.count())
+	}
+
+	// Window scoped to a different service must not suppress "api".
+	r.AddWindow(MaintenanceWindow{Name: "other", Start: now.Add(-time.Hour), End: now.Add(time.Hour), Services: []string{"billing"}})
+	if err := r.Notify(context.Background(), Notification{Service: "api"}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if ch.count() != 2 {
+		t.Errorf("out-of-scope window should not suppress; sends = %d, want 2", ch.count())
+	}
+}
+
+func TestTeamRouting_DeliversAndDedups(t *testing.T) {
+	teamCh := &recordChannel{typ: "slack"}
+	r := NewRouter()
+	r.RegisterChannel("team-a", teamCh)
+	r.SetTeam(Team{Name: "team-a", Channels: []ChannelRef{{Type: "slack", Name: "team-a"}}}, []string{"api"})
+
+	// No direct route — the owning team's channel still receives it.
+	if err := r.Notify(context.Background(), Notification{Service: "api"}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if teamCh.count() != 1 {
+		t.Fatalf("team channel sends = %d, want 1", teamCh.count())
+	}
+
+	// A service with no owning team gets nothing from team routing.
+	if err := r.Notify(context.Background(), Notification{Service: "unowned"}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if teamCh.count() != 1 {
+		t.Errorf("unowned service must not hit team channel; sends = %d, want 1", teamCh.count())
+	}
+
+	// Dedup: a direct route to the same channel means the team loop skips it (1 send, not 2).
+	r.AddRoute(Route{Name: "direct", Match: RouteMatch{Services: []string{"api"}}, Channels: []ChannelRef{{Type: "slack", Name: "team-a"}}, Enabled: true})
+	before := teamCh.count()
+	if err := r.Notify(context.Background(), Notification{Service: "api"}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if got := teamCh.count() - before; got != 1 {
+		t.Errorf("route+team to same channel should send once; got %d sends", got)
+	}
+}

--- a/pkg/notify/types.go
+++ b/pkg/notify/types.go
@@ -67,6 +67,50 @@ type ChannelRef struct {
 	Config map[string]string `json:"config"` // webhook_url, routing_key, etc.
 }
 
+// MaintenanceWindow suppresses notifications during a scheduled time range.
+// An empty Services or Severities slice means "all". This is a routing-layer
+// suppression, distinct from pkg/monitor's per-monitor MutedUntil.
+type MaintenanceWindow struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	Start      time.Time `json:"start"`
+	End        time.Time `json:"end"`
+	Services   []string  `json:"services,omitempty"`
+	Severities []string  `json:"severities,omitempty"`
+}
+
+// suppresses reports whether this window is active at now and its scope covers
+// the notification.
+func (w MaintenanceWindow) suppresses(n Notification, now time.Time) bool {
+	if now.Before(w.Start) || now.After(w.End) {
+		return false
+	}
+	if len(w.Services) > 0 && !containsStr(w.Services, n.Service) {
+		return false
+	}
+	if len(w.Severities) > 0 && !containsStr(w.Severities, n.Severity) {
+		return false
+	}
+	return true
+}
+
+// Team owns one or more notification channels. Notifications for a service
+// owned by a team are also delivered to the team's channels (supplementing any
+// direct service→channel routes, which remain unchanged).
+type Team struct {
+	Name     string       `json:"name"`
+	Channels []ChannelRef `json:"channels"`
+}
+
+func containsStr(ss []string, v string) bool {
+	for _, s := range ss {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
 // ChannelSchema describes a channel type's configuration schema for the API.
 type ChannelSchema struct {
 	Type        string              `json:"type"`


### PR DESCRIPTION
Two routing-layer enhancements from the audit roadmap (`docs/v1-feature-roadmap.md:125-126`), both implemented in the `Router` with **no behavior change when unconfigured**.

## Maintenance windows (alert suppression)
- `MaintenanceWindow{Start, End, Services, Severities}` — empty scope means "all". `Router.Notify` checks active windows **first** and, when one covers the notification, records a `"suppressed"` delivery and dispatches to nothing. Distinct from `pkg/monitor`'s per-monitor `MutedUntil` (which doesn't cover the routing layer).
- Methods: `AddWindow` / `RemoveWindow` / `ListWindows` / `LoadWindows`.

## Team-tier routing
- `Team{Name, Channels}` + a service→team mapping (`SetTeam`). `Notify` also delivers to the **owning team's channels**, deduped against any direct-route channels — so existing service→channel routes are unchanged and a shared channel isn't double-sent.

The per-channel resolve/send/record logic is factored into a shared `dispatch()` helper.

## Tests
- Window suppression: active (suppresses), expired (doesn't), out-of-scope service (doesn't).
- Team delivery for owned vs unowned services; route+team dedup to the same channel sends once.
- Full `pkg/notify` suite passes unchanged.

> Router primitives + `Load*` are in place; thin admin endpoints to manage windows/teams at runtime can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)