### PR TITLE
feat(admin): correlate error groups to deploys via Release

### DIFF
--- a/pkg/admin/error_correlation.go
+++ b/pkg/admin/error_correlation.go
@@ -1,0 +1,96 @@
+package admin
+
+import (
+	"net/http"
+	"strings"
+
+	errs "github.com/Viridian-Inc/cloudmock/pkg/errors"
+)
+
+// ErrorDeployLink links an error group to the deploy(s) it was first seen in,
+// correlating ErrorGroup.Release against known deploy records.
+type ErrorDeployLink struct {
+	GroupID string        `json:"group_id"`
+	Message string        `json:"message"`
+	Release string        `json:"release"`
+	Status  string        `json:"status"`
+	Count   int           `json:"count"`
+	Deploys []DeployEvent `json:"deploys"`
+}
+
+// handleErrorDeployCorrelation handles GET /api/errors/deploys — for each error
+// group that carries a Release matching a known deploy, return the group with
+// its matching deploys.
+func (a *API) handleErrorDeployCorrelation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if a.errorStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "error tracking not enabled")
+		return
+	}
+
+	groups, err := a.errorStore.GetGroups("", 500)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	a.deploysMu.RLock()
+	deploys := make([]DeployEvent, len(a.deploys))
+	copy(deploys, a.deploys)
+	a.deploysMu.RUnlock()
+
+	links := correlateErrorDeploys(groups, deploys)
+	if links == nil {
+		links = []ErrorDeployLink{}
+	}
+	writeJSON(w, http.StatusOK, links)
+}
+
+// correlateErrorDeploys joins error groups to deploys by ErrorGroup.Release.
+func correlateErrorDeploys(groups []errs.ErrorGroup, deploys []DeployEvent) []ErrorDeployLink {
+	var links []ErrorDeployLink
+	for _, g := range groups {
+		if g.Release == "" {
+			continue
+		}
+		var matched []DeployEvent
+		for _, d := range deploys {
+			if deployMatchesRelease(d, g.Release) {
+				matched = append(matched, d)
+			}
+		}
+		if len(matched) > 0 {
+			links = append(links, ErrorDeployLink{
+				GroupID: g.ID,
+				Message: g.Message,
+				Release: g.Release,
+				Status:  g.Status,
+				Count:   g.Count,
+				Deploys: matched,
+			})
+		}
+	}
+	return links
+}
+
+// deployMatchesRelease reports whether a deploy corresponds to an error group's
+// release tag. A release is commonly a commit SHA (full or short), a branch, or
+// a deploy ID, so we match on any of those — including a short/full commit
+// prefix relationship.
+func deployMatchesRelease(d DeployEvent, release string) bool {
+	if release == "" {
+		return false
+	}
+	if release == d.Commit || release == d.Branch || release == d.ID {
+		return true
+	}
+	if d.Commit != "" && len(release) >= 7 {
+		if strings.HasPrefix(d.Commit, release) || strings.HasPrefix(release, d.Commit) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/admin/error_correlation_test.go
+++ b/pkg/admin/error_correlation_test.go
@@ -1,0 +1,52 @@
+package admin
+
+import (
+	"testing"
+
+	errs "github.com/Viridian-Inc/cloudmock/pkg/errors"
+)
+
+func TestDeployMatchesRelease(t *testing.T) {
+	d := DeployEvent{ID: "deploy-1", Commit: "abcdef1234567890", Branch: "main"}
+	cases := []struct {
+		release string
+		want    bool
+	}{
+		{"abcdef1234567890", true}, // exact commit
+		{"abcdef1", true},          // short commit prefix (>=7)
+		{"main", true},             // branch
+		{"deploy-1", true},         // deploy id
+		{"abc", false},             // too-short prefix
+		{"zzzzzzz", false},         // no match
+		{"", false},                // empty release
+	}
+	for _, c := range cases {
+		if got := deployMatchesRelease(d, c.release); got != c.want {
+			t.Errorf("deployMatchesRelease(%q) = %v, want %v", c.release, got, c.want)
+		}
+	}
+}
+
+func TestCorrelateErrorDeploys(t *testing.T) {
+	groups := []errs.ErrorGroup{
+		{ID: "g1", Message: "boom", Release: "abcdef1234567890", Status: "unresolved", Count: 5},
+		{ID: "g2", Message: "no release", Release: ""},          // skipped (no release)
+		{ID: "g3", Message: "unmatched", Release: "deadbeef99"}, // no matching deploy
+	}
+	deploys := []DeployEvent{
+		{ID: "d1", Service: "bff", Commit: "abcdef1234567890", Branch: "main", Author: "alice"},
+		{ID: "d2", Service: "api", Commit: "0000000000000000", Branch: "release"},
+	}
+
+	links := correlateErrorDeploys(groups, deploys)
+	if len(links) != 1 {
+		t.Fatalf("got %d links, want 1: %+v", len(links), links)
+	}
+	l := links[0]
+	if l.GroupID != "g1" || l.Release != "abcdef1234567890" || l.Count != 5 {
+		t.Errorf("link = %+v", l)
+	}
+	if len(l.Deploys) != 1 || l.Deploys[0].ID != "d1" {
+		t.Errorf("matched deploys = %+v, want [d1]", l.Deploys)
+	}
+}

--- a/pkg/admin/error_handlers.go
+++ b/pkg/admin/error_handlers.go
@@ -52,6 +52,12 @@ func (a *API) handleErrorByID(w http.ResponseWriter, r *http.Request) {
 
 	path := strings.TrimPrefix(r.URL.Path, "/api/errors/")
 
+	// GET /api/errors/deploys — error groups correlated to deploys by Release.
+	if path == "deploys" {
+		a.handleErrorDeployCorrelation(w, r)
+		return
+	}
+
 	// PUT /api/errors/:id/status
 	if strings.HasSuffix(path, "/status") {
 		if r.Method != http.MethodPut {


### PR DESCRIPTION
`ErrorGroup.Release` was a free-text string with no linkage to deploy records (audit roadmap item, `docs/v1-feature-roadmap.md:27`). Adds a correlation that joins error groups to the deploys they were first seen in.

## Changes
- **`GET /api/errors/deploys`** — returns, for each error group whose `Release` matches a known deploy, the group plus its matching deploys (`ErrorDeployLink`). Routed via the existing `handleErrorByID` sub-path dispatch (`path == "deploys"`), so no new mux pattern / precedence concern.
- `deployMatchesRelease` matches a `Release` against a deploy's **commit** (full or short prefix, ≥7 chars), **branch**, or **deploy ID**.

Correlates against the in-memory deploy list (consistent with the existing `/api/explain` deploy scan; DataPlane-mode deploys are a noted follow-up).

## Tests
- `deployMatchesRelease`: exact commit, short-commit prefix, branch, deploy id, too-short/no-match, empty.
- `correlateErrorDeploys`: matched group linked; release-less and unmatched groups excluded.

`go vet` clean; full `pkg/admin` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)