### PR TITLE
feat(rum): correlate RUM JS errors to backend traces via trace id

### DIFF
--- a/pkg/admin/rum_handlers.go
+++ b/pkg/admin/rum_handlers.go
@@ -176,6 +176,9 @@ func (a *API) handleRUMErrors(w http.ResponseWriter, r *http.Request) {
 			"affected_sessions": g.Sessions,
 			"last_seen":         g.LastSeen.Format("2006-01-02T15:04:05Z"),
 			"sample_stack":      g.Stack,
+			// Correlate the RUM JS error to its backend distributed trace.
+			"trace_id":          g.TraceID,
+			"has_backend_trace": g.TraceID != "" && a.traceStore != nil && a.traceStore.Get(g.TraceID) != nil,
 		}
 	}
 	writeJSON(w, http.StatusOK, result)

--- a/pkg/rum/memory/store.go
+++ b/pkg/rum/memory/store.go
@@ -224,6 +224,9 @@ func (s *Store) ErrorGroups() ([]rum.ErrorGroup, error) {
 		g.Count++
 		if e.Timestamp.After(g.LastSeen) {
 			g.LastSeen = e.Timestamp
+			if e.TraceID != "" {
+				g.TraceID = e.TraceID // representative: the most recent occurrence's trace
+			}
 		}
 		groupSessions[fp][e.SessionID] = struct{}{}
 	}

--- a/pkg/rum/memory/trace_correlation_test.go
+++ b/pkg/rum/memory/trace_correlation_test.go
@@ -1,0 +1,46 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	rum "github.com/Viridian-Inc/cloudmock/pkg/rum"
+)
+
+// A RUM JS error group should carry the most-recent occurrence's backend trace
+// id so it can be correlated to a distributed trace.
+func TestErrorGroups_CarriesTraceID(t *testing.T) {
+	s := NewStore(100)
+
+	older := makeEvent(rum.EventJSError, "s1")
+	older.Timestamp = time.Now().Add(-time.Minute)
+	older.TraceID = "trace-old"
+	older.JSError = &rum.JSErrorEvent{Message: "boom", Fingerprint: "fp1"}
+
+	newer := makeEvent(rum.EventJSError, "s2")
+	newer.Timestamp = time.Now()
+	newer.TraceID = "trace-new"
+	newer.JSError = &rum.JSErrorEvent{Message: "boom", Fingerprint: "fp1"}
+
+	if err := s.WriteEvent(older); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteEvent(newer); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, err := s.ErrorGroups()
+	if err != nil {
+		t.Fatalf("ErrorGroups: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+	if groups[0].Count != 2 {
+		t.Errorf("count = %d, want 2", groups[0].Count)
+	}
+	// Representative trace is the most recent occurrence's.
+	if groups[0].TraceID != "trace-new" {
+		t.Errorf("TraceID = %q, want trace-new (most recent)", groups[0].TraceID)
+	}
+}

--- a/pkg/rum/types.go
+++ b/pkg/rum/types.go
@@ -22,6 +22,7 @@ type RUMEvent struct {
 	URL       string    `json:"url"`
 	UserAgent string    `json:"user_agent"`
 	Timestamp time.Time `json:"timestamp"`
+	TraceID   string    `json:"trace_id,omitempty"` // backend distributed trace this event belongs to
 
 	// Exactly one of these will be populated, depending on Type.
 	PageLoad       *PageLoadEvent       `json:"page_load,omitempty"`
@@ -109,6 +110,7 @@ type ErrorGroup struct {
 	Sessions    int       `json:"sessions"`
 	LastSeen    time.Time `json:"last_seen"`
 	Stack       string    `json:"stack"`
+	TraceID     string    `json:"trace_id,omitempty"` // most-recent event's backend trace, if any
 }
 
 // SessionSummary is a lightweight view of a user session.


### PR DESCRIPTION
Adds the backend **trace-id data model + correlation** for RUM (audit roadmap item, `docs/v1-feature-roadmap.md:83`). The browser-SDK capture of the trace id is the remaining frontend piece; this lands the Go backend the audit said is separately deliverable.

## Changes
- **`pkg/rum`** — `RUMEvent.TraceID` (flows through memory/filestore/dynamostore automatically, since they persist the event struct) and `ErrorGroup.TraceID`. The memory aggregation records the **most-recent occurrence's** trace id as the group's representative trace.
- **`pkg/admin` `handleRUMErrors`** — surface `trace_id` plus **`has_backend_trace`** (true when that trace exists in the gateway `TraceStore`), so a RUM JS error resolves to its distributed trace.

## Test
- An error group aggregated from two occurrences carries the **most recent** occurrence's trace id.

`go build`/`vet` clean; full `pkg/rum/...` + `pkg/admin` suites pass.

> Implemented in an isolated `git worktree` to avoid colliding with concurrent Azure work in the shared working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)