### PR TITLE
feat(errors): auto-generate explanation when a group crosses 5 occurrences

### DIFF
--- a/pkg/errors/explain.go
+++ b/pkg/errors/explain.go
@@ -1,0 +1,48 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// AutoExplainThreshold is the occurrence count at which an error group is
+// automatically given an explanation.
+const AutoExplainThreshold = 5
+
+// BuildAutoExplanation produces a short, deterministic explanation for an error
+// group that has become significant (crossed AutoExplainThreshold occurrences).
+// It is generated from the group's own data — no external LLM, no cross-package
+// dependency — so it can be computed inline during ingest.
+func BuildAutoExplanation(g *ErrorGroup) string {
+	if g == nil {
+		return ""
+	}
+	kind := g.Type
+	if kind == "" {
+		kind = "error"
+	}
+
+	var b strings.Builder
+	msg := g.Message
+	if msg == "" {
+		msg = "(no message)"
+	}
+	fmt.Fprintf(&b, "%q has occurred %d times", msg, g.Count)
+	if g.Sessions > 0 {
+		fmt.Fprintf(&b, " across %d session(s)", g.Sessions)
+	}
+	if !g.FirstSeen.IsZero() {
+		fmt.Fprintf(&b, " since %s", g.FirstSeen.UTC().Format(time.RFC3339))
+	}
+	b.WriteString(".")
+	if g.Source != "" {
+		fmt.Fprintf(&b, " Source: %s.", g.Source)
+	}
+	if g.Release != "" {
+		fmt.Fprintf(&b, " First seen in release %s.", g.Release)
+	}
+	fmt.Fprintf(&b, " It crossed the %d-occurrence threshold, so this %s is a recurring issue worth investigating.",
+		AutoExplainThreshold, kind)
+	return b.String()
+}

--- a/pkg/errors/memory/auto_explain_test.go
+++ b/pkg/errors/memory/auto_explain_test.go
@@ -1,0 +1,56 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+
+	errs "github.com/Viridian-Inc/cloudmock/pkg/errors"
+)
+
+func TestIngestError_AutoExplainOnThreshold(t *testing.T) {
+	s := NewStore(100)
+	ev := errs.ErrorEvent{Message: "boom", Stack: "at handler.js:10", Service: "api", SessionID: "s1", Release: "v1.2.3"}
+
+	// Below the threshold: no explanation yet.
+	for i := 0; i < errs.AutoExplainThreshold-1; i++ {
+		if err := s.IngestError(ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+	groups, err := s.GetGroups("", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("groups = %d, want 1", len(groups))
+	}
+	if groups[0].AutoExplanation != "" {
+		t.Errorf("explanation set before threshold: %q", groups[0].AutoExplanation)
+	}
+
+	// The threshold-th occurrence triggers the explanation.
+	if err := s.IngestError(ev); err != nil {
+		t.Fatal(err)
+	}
+	groups, _ = s.GetGroups("", 10)
+	if groups[0].Count != errs.AutoExplainThreshold {
+		t.Fatalf("count = %d, want %d", groups[0].Count, errs.AutoExplainThreshold)
+	}
+	exp := groups[0].AutoExplanation
+	if exp == "" {
+		t.Fatal("explanation not generated at threshold")
+	}
+	for _, want := range []string{"boom", "recurring", "v1.2.3"} {
+		if !strings.Contains(exp, want) {
+			t.Errorf("explanation %q missing %q", exp, want)
+		}
+	}
+
+	// Further occurrences must not overwrite/regenerate it.
+	before := groups[0].AutoExplanation
+	_ = s.IngestError(ev)
+	groups, _ = s.GetGroups("", 10)
+	if groups[0].AutoExplanation != before {
+		t.Errorf("explanation regenerated after threshold")
+	}
+}

--- a/pkg/errors/memory/store.go
+++ b/pkg/errors/memory/store.go
@@ -81,6 +81,11 @@ func (s *Store) IngestError(event errs.ErrorEvent) error {
 		}
 	}
 
+	// Auto-generate an explanation once the group crosses the threshold.
+	if g.Count == errs.AutoExplainThreshold && g.AutoExplanation == "" {
+		g.AutoExplanation = errs.BuildAutoExplanation(g)
+	}
+
 	// Write event to circular buffer.
 	s.events[s.pos] = event
 	s.pos = (s.pos + 1) % s.cap

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -16,6 +16,9 @@ type ErrorGroup struct {
 	Status    string            `json:"status"`  // "unresolved", "resolved", "ignored"
 	Release   string            `json:"release"` // release/deploy where first seen
 	Tags      map[string]string `json:"tags"`
+	// AutoExplanation is a deterministic summary generated once the group
+	// crosses AutoExplainThreshold occurrences.
+	AutoExplanation string `json:"auto_explanation,omitempty"`
 }
 
 // ErrorEvent represents a single error occurrence.


### PR DESCRIPTION
When an error group reaches **`AutoExplainThreshold` (5)** occurrences during ingest, attach a deterministic explanation summarizing it (audit roadmap item, `docs/v1-feature-roadmap.md:36`).

## Design (sidesteps the blockers)
The audit suggested invoking `pkg/admin`'s explain logic from `pkg/errors` ingest — but `pkg/errors` can't import `pkg/admin`, and a callback risks re-entrant deadlock under the store lock. Instead, the explanation is generated **inline from the group's own data** via `errors.BuildAutoExplanation` — **no external LLM, no cross-package call, no callback, no `ErrorStore` interface change**. It's computed **exactly once** (when `Count` hits the threshold) and stored on `ErrorGroup.AutoExplanation` (a struct field, so it flows straight to API responses).

Implemented in the memory store's `IngestError` — the audit's explicit target and the default dev store.

## Tests
- No explanation below the threshold.
- Generated at the threshold (mentions the message, release, "recurring").
- **Not** regenerated/overwritten on further occurrences.

`go vet` clean; full `pkg/errors/...` suite passes. Built in an isolated worktree (no collision with concurrent Azure work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)